### PR TITLE
Add readthedocs content

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -6,6 +6,7 @@ toc: true
 
 - [Overview](/docs/overview/)
 - [Metadata and QC](/docs/sample_metadata/)
+- [OSF links](/docs/osf_links/)
 - [SQLite metadata](/docs/metadata_sqlite/)
 - [Assemblies](/docs/assemblies/)
 - [Species identification](/docs/species_id/)

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -15,6 +15,7 @@ toc: true
 - [Defense systems](/docs/defense/)
 - [Biosynthetic gene clusters](/docs/bgcs/)
 - [Hypothetical protein structures](/docs/hypothetical_protein_structures/)
+- [WhatsGNU protein allele frequencies](/docs/whatsgnu_panallelome/)
 - [Species specific typing](/docs/typing/)
 - [Archaea](/docs/archaea/)
 - [Sequence alignment with LexicMap](/docs/lexicmap/)

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -3,237 +3,36 @@ title: Documentation
 layout: docs
 toc: true
 ---
-__Full documentation is on [readthedocs ↗](https://allthebacteria.readthedocs.io/en/latest/).__
 
-Some highlighted features are also documented here
-
-## Searching and querying the assemblies
-
-The ATB dataset has been indexed with [LexicMap](https://github.com/shenwei356/LexicMap) which supports
-searching and alignment to the full dataset (i.e. a BLAST-like search) using sequences >100bp in length.
-
-{{< tabs items="Local,AWS" >}}
-
-  {{< tab >}}
-
-    ### Local search with pre-built index
-    This option avoids the high RAM indexing, but it does mean you have a very large (5 Tb) download.
-
-    Install `awscli` via conda.
-    ```
-    conda install -c conda-forge awscli
-    ```
-
-    Test access.
-    ```
-    aws s3 ls s3://allthebacteria-lexicmap/202408/ --no-sign-request
-
-    # output
-                                PRE genomes/
-                                PRE seeds/
-        2025-04-08 16:39:17      62488 genomes.chunks.bin
-        2025-04-08 16:39:17   54209660 genomes.map.bin
-        2025-04-08 22:32:35        619 info.toml
-        2025-04-08 22:32:36     160032 masks.bin
-    ```
-
-    Download the index (it’s 5.24 TiB!!!, make sure you have enough disk space).
-
-    ```
-    aws s3 cp s3://allthebacteria-lexicmap/202408/ atb.lmi --recursive --no-sign-request
-
-    # dirsize atb.lmi
-    atb.lmi: 5.24 TiB (5,758,875,365,595)
-        2.87 TiB      seeds
-        2.37 TiB      genomes
-        51.70 MiB      genomes.map.bin
-    156.28 KiB      masks.bin
-        61.02 KiB      genomes.chunks.bin
-            619 B      info.toml
-    ```
-
-    [Install](https://bioinf.shenwei.me/LexicMap/installation/>) and [search](https://bioinf.shenwei.me/LexicMap/tutorials/search/) with LexicMap.
-
-    ### Building an index and searching locally
-
-    This option requires a small (80Gb) download, but indexing the assemblies took 150Gb RAM, and 47 hours with 48 CPUs.
-
-    **Make sure you have enough disk space, at least 8 TB, >10 TB is preferred.**
-
-    Tools:
-
-    -  [LexicMap](https://bioinf.shenwei.me/LexicMap/installation/)
-    -  https://github.com/shenwei356/rush, for running jobs in parallel
-
-    Steps:
-
-    1. Downloading the list file of all [assemblies](https://osf.io/zxfmy/) in the latest version (v0.2 plus incremental versions).
-    ```
-    mkdir -p atb;
-    cd atb;
-
-    # Attention, the URL might change,
-    # please check in the browser: https://osf.io/zxfmy/files/osfstorage
-    wget https://osf.io/download/4yv85/ -O file_list.all.latest.tsv.gz
-    ```
-
-    If you only need to add assemblies from an incremental version,
-    please manually download the file list [here](https://osf.io/zxfmy/files/osfstorage>).
-
-    2. Downloading assembly tarball files.
-
-    ```
-    # Tarball file names and their URLs
-    zcat file_list.all.latest.tsv.gz | awk 'NR>1 {print $3"\t"$4}' | uniq > tar2url.tsv
-
-    # Download. If it's interrupted, just rerun the same command.
-    cat tar2url.tsv | rush --eta -j 2 -c -C download.rush 'wget -O {1} {2}'
-    ```
-
-    3. Decompressing all tarballs. The decompressed genomes are stored in
-    plain text, so we use `gzip` (can be replaced with faster `pigz`)
-    to compress them to save disk space.
-
-    ```
-    # {^tar.xz} is for removing the suffix "tar.xz"
-    ls *.tar.xz | rush --eta -c -C decompress.rush 'tar -Jxf {}; gzip -f {^.tar.xz}/*.fa'
-
-    cd ..
-    ```
-
-    After that, the assemblies directory would have multiple
-    subdirectories. When you give the directory to `lexicmap index -I`,
-    it can recursively scan (plain or gz/xz/zstd-compressed) genome
-    files. You can also give a file list with selected assemblies.
-    ```
-        $ tree atb | more
-        atb
-        ├── atb.assembly.r0.2.batch.1
-        │   ├── SAMD00013333.fa.gz
-        │   ├── SAMD00049594.fa.gz
-        │   ├── SAMD00195911.fa.gz
-        │   ├── SAMD00195914.fa.gz
-    ```
-
-    4. Prepare a file list of assemblies.
-
-    -  Just use `find` or [`fd`](https://github.com/sharkdp/fd) (much
-        faster).
-
-        ```
-        # find
-        find atb/ -name "*.fa.gz" > files.txt
-
-        # fd
-        fd .fa.gz$ atb/ > files.txt
-        ```
-
-        What it looks like:
-
-        ```
-        $ head -n 2 files.txt
-        atb/atb.assembly.r0.2.batch.1/SAMD00013333.fa.gz
-        atb/atb.assembly.r0.2.batch.1/SAMD00049594.fa.gz
-        ```
-
-    -  (Optional) Only keep assemblies of high-quality.
-        Please [click this link](https://osf.io/download/m26zn/) to
-        download the `hq_set.sample_list.txt.gz` file, or from this
-        [page](https://osf.io/h7wzy/files/osfstorage/).
-
-        ```
-        find atb/ -name "*.fa.gz" | grep -w -f <(zcat hq_set.sample_list.txt.gz) > files.txt
-        ```
-
-    5. Creating a LexicMap index ([tutorials](https://bioinf.shenwei.me/LexicMap/tutorials/index/>)).
-    It took 47h40m and 145GB RAM with 48 CPUs for 2.44 million ATB genomes.
-
-    ```
-    lexicmap index -S -X files.txt -O atb.lmi -b 25000 --log atb.lmi.log
-
-    # dirsize atb.lmi
-    atb.lmi: 5.24 TiB (5,758,875,365,595)
-        2.87 TiB      seeds
-        2.37 TiB      genomes
-        51.70 MiB      genomes.map.bin
-    156.28 KiB      masks.bin
-        61.02 KiB      genomes.chunks.bin
-            619 B      info.toml
-    ```
-
-    6. Searching with LexicMap ([tutorial](https://bioinf.shenwei.me/LexicMap/tutorials/search/)).
-
-  {{< /tab >}}
-
-  {{< tab >}}
-    ### Searching on AWS EC2
-
-    1. [Launch an EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
-    **in Europe London region (eu-west-2)** where the index is located.
-
-    -  OS: Amazon Linux 2023 64-bit (**Arm**)
-    -  Instance type (You might need to [increase the limit of CPUs](http://aws.amazon.com/contact-us/ec2-request)):
-
-        -  c7g.8xlarge (32 vCPU, 64 GiB memory, 15 Gigabit, 1.3738 USD per Hour)
-        -  c6gn.12xlarge (48 vCPU, 96 GiB memory, 75 Gigabit, 2.46 USD per Hour) (**recommended**)
-
-    -  Storage: 20 GiB General purpose (gp3), only for storing queries and results.
-
-    2. [Connect to the instance via online console or a ssh client](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect.html).
-
-    3. Mount the LexicMap index with [mount-s3](https://github.com/awslabs/mountpoint-s3>) (it’s fast but still slower than local disks).
-
-    ```
-    # Install mount-s3. You might need to replace arm64 with x86_64 for other architectures
-    wget https://s3.amazonaws.com/mountpoint-s3-release/latest/arm64/mount-s3.rpm
-    sudo yum install -y ./mount-s3.rpm
-    rm ./mount-s3.rpm
-
-    # Mount the v0.2+202408 index
-    mkdir -p atb.lmi
-    UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE=65536 \
-        mount-s3 --read-only --prefix 202408/ allthebacteria-lexicmap atb.lmi --no-sign-request
-    ```
-
-    4. Install LexicMap.
-
-    ```
-    # Check the latest version here: https://github.com/shenwei356/LexicMap/releases
-    # You can also check the pre-release here: https://github.com/shenwei356/LexicMap/issues/10
-    # Binary's path depends on the architecture of the CPUs: amd64 or arm64
-    wget https://github.com/shenwei356/LexicMap/releases/download/v0.7.0/lexicmap_linux_arm64.tar.gz
-
-    mkdir -p bin
-    tar -zxvf lexicmap_linux_arm64.tar.gz -C bin
-    rm lexicmap_linux_arm64.tar.gz
-    ```
-
-    5. [Upload queries](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/linux-file-transfer-scp.html>)
-    ```
-    # Here, we use a demo query
-    wget https://github.com/shenwei356/LexicMap/raw/refs/heads/main/demo/bench/b.gene_E_faecalis_SecY.fasta
-    ```
-
-    6. Run LexicMap ([tutorial](https://bioinf.shenwei.me/LexicMap/tutorials/search/>)).
-
-    ```
-        # Create and enter a screen session
-        screen -S lexicmap
-
-        # Run
-        #   Searching with b.gene_E_faecalis_SecY.fasta takes 20 minutes with c7g.8xlarge, 12.5 minutes with c6gn.12xlarge
-        #   Searching with b.gene_E_coli_16S.fasta      takes 1h54m with c6gn.12xlarge.
-        lexicmap search -d atb.lmi b.gene_E_faecalis_SecY.fasta -o query.lexicmap.txt.gz --debug
-    ```
-
-    7. Unmount the index.
-
-    ```
-        sudo umount atb.lmi
-    ```
-  {{< /tab >}}
-
-{{< /tabs >}}
-
-
-
+All WGS isolate bacterial INSDC data to August 2024 uniformly assembled,
+QC-ed, annotated, searchable.
+
+Follow up to Grace Blackwell's 661k dataset (which covered everything to
+Nov 2018).
+
+Preprint: <https://doi.org/10.1101/2024.03.08.584059>
+
+Please use the github repository to raise any issues:
+<https://github.com/AllTheBacteria/AllTheBacteria/issues>
+
+
+## Pages
+
+- [Overview](/docs/overview/)
+- [Metadata and QC](/docs/sample_metadata/)
+- [SQLite metadata](/docs/metadata_sqlite/)
+- [Assemblies](/docs/assemblies/)
+- [Species identification](/docs/species_id/)
+- [Annotation](/docs/annotation/)
+- [Antimicrobial resistance](/docs/amr/)
+- [Defense systems](/docs/defense/)
+- [Biosynthetic gene clusters](/docs/bgcs/)
+- [Hypothetical protein structures](/docs/hypothetical_protein_structures/)
+- [Species specific typing](/docs/typing/)
+- [Archaea](/docs/archaea/)
+- [Sequence alignment with LexicMap](/docs/lexicmap/)
+- [Contributing to AllTheBacteria](/docs/contributing/)
+- [Batch downloading from OSF](/docs/osf_downloads/)
+- [FAQ](/docs/faq/)
+- [Release history](/docs/release_history/)
+- [Migration from EBI FTP to OSF](/docs/ebi2osf/)

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,20 +4,6 @@ layout: docs
 toc: true
 ---
 
-All WGS isolate bacterial INSDC data to August 2024 uniformly assembled,
-QC-ed, annotated, searchable.
-
-Follow up to Grace Blackwell's 661k dataset (which covered everything to
-Nov 2018).
-
-Preprint: <https://doi.org/10.1101/2024.03.08.584059>
-
-Please use the github repository to raise any issues:
-<https://github.com/AllTheBacteria/AllTheBacteria/issues>
-
-
-## Pages
-
 - [Overview](/docs/overview/)
 - [Metadata and QC](/docs/sample_metadata/)
 - [SQLite metadata](/docs/metadata_sqlite/)

--- a/content/docs/amr.md
+++ b/content/docs/amr.md
@@ -1,0 +1,34 @@
+---
+title: Antimicrobial resistance
+weight: 7
+toc: true
+---
+
+## AMRFinderPlus
+
+The results of running AMRFinderPlus for AllTheBacteria are available on
+OSF in the [AMRFinderPlus component](https://osf.io/7nwrx/). The results
+are organized into folders based on the version of `amrfinder` that was
+used, and sub-folders within these based on the `amrfinder database`
+version used. The dataset is frequently updated; therefore, we also
+include sub-folders of the results broken down by the AllTheBacteria
+release, useful if you just want the results for a new incremental
+release. The `latest` subfolder contains the most recent aggregated
+results of running on all samples in the AllTheBacteria dataset and can
+be found here: [AMRFP_results.tsv.gz](https://osf.io/ck7st).
+
+Each table of results has a matched status file. The status file
+indicates which samples we have run `amrfinder` on in the `sample`
+column, whether the run completed successfully (`PASS`), failed
+(`FAIL`), or is yet to be run (`NOT DONE`) in the `status` column. There
+is an additional column for any comments, such as indicating if the
+output of `amrfinder` was empty if no AMR determinants were identified.
+We also include a copy of the `amrfinder` database we used in each
+`database` sub-folder.
+
+A Snakemake workflow to rerun this analysis can be found on the
+AllTheBacteria GitHub page
+[here](https://github.com/AllTheBacteria/AllTheBacteria/tree/main/reproducibility/All-samples/AMR/AMRFinderPlus)
+and modified fairly easily to use newer software or database versions.
+If you want to do this and have any questions or need some help, please
+contact [Daniel Anderson](mailto:dander@ebi.ac.uk).

--- a/content/docs/amr.md
+++ b/content/docs/amr.md
@@ -1,6 +1,6 @@
 ---
 title: Antimicrobial resistance
-weight: 7
+weight: 80
 toc: true
 ---
 

--- a/content/docs/annotation.md
+++ b/content/docs/annotation.md
@@ -1,6 +1,6 @@
 ---
 title: Annotation
-weight: 6
+weight: 70
 toc: true
 ---
 

--- a/content/docs/annotation.md
+++ b/content/docs/annotation.md
@@ -1,0 +1,63 @@
+---
+title: Annotation
+weight: 6
+toc: true
+---
+
+## Bakta
+
+All assembled ATB sample genomes were annotated using Bakta
+[v1.9.4](https://github.com/oschwengers/bakta/releases/tag/v1.9.4) using
+its `full` database
+[v5.1](https://doi.org/10.5281/zenodo.10522951). Bakta was run in a
+Conda environment using its public
+[Bioconda](https://bioconda.github.io/recipes/bakta/README.html)
+package.
+
+Result files are available on OSF in the [Bakta
+component](https://osf.io/zt57s/). However, due to the huge amount of
+raw annotation data (\>35 TB), a couple of measures have been taken to
+handle this. First, only JSON files are provided since all Bakta output
+files can be restored from those (see below). Second, sample result
+files are packed in taxonomic batches, just like assembled FASTA files
+to achieve better compression ratios. Third, since there are OSF data
+size limits of 50 GB and 5 GB for compartments and files, respectively,
+all taxonomy batches were further distributed to several compartments.
+Furthermore, some taxonomy batches had to be split into separate files
+to meet the 5 GB file limit. By doing so, all annotation data could be
+reduced to a total of ~1.3 TB and ~0.3 TB for `r0.2` and
+`incr_release.202408`, respectively.
+
+For each release, there is a status file in a `File_Lists` folder, e.g.
+`atb.bakta.r0.2.status.tsv.gz` providing
+the following information:
+
+- `sample` = the INSDC sample accession
+- `status` = the status of the Bakta run (`PASS`, `FAIL`)
+- `file_name` = the name of the Bakta JSON result file, e.g.
+  `SAMN38372697.bakta.json`
+- `file_md5` = MD5 sum of `file_name`
+- `tar_xz` = the name of the tar.xz file where this sample's JSON lives
+  following a fix schema: atb. `analysis` . `release` . `batch` .tar.xz,
+  e.g. `atb.bakta.r0.2.batch.1.tar.xz`
+- `tar_xz_md5` = MD5 sum of `tar_xz`
+- `tar_xz_size_MB` = size of the `tar_xz`
+  file in MB
+
+Example \`SAMN38372697\`:
+
+    sample          SAMN38372697
+    status          PASS
+    file_name       SAMN38372697.bakta.json
+    file_md5        008d86ad046e0d152b8cc22d7452be24
+    tar_xz          atb.bakta.incr_release.202408.batch.29.tar.xz
+    tar_xz_md5      7da90ac7650de2c2e0b821569ae2a602
+    tar_xz_size_MB  1201.0
+
+To restore all output files for a given sample from its JSON file, use
+the following command:
+
+    bakta_io --output <output-path> --prefix <file-prefix> sample.json
+
+For any questions regarding the Bakta genome annotation, please contact
+[Oliver Schwengers](mailto:oliver.schwengers@cb.jlug.de).

--- a/content/docs/archaea.md
+++ b/content/docs/archaea.md
@@ -1,6 +1,6 @@
 ---
 title: Archaea
-weight: 12
+weight: 130
 toc: true
 ---
 

--- a/content/docs/archaea.md
+++ b/content/docs/archaea.md
@@ -1,0 +1,21 @@
+---
+title: Archaea
+weight: 12
+toc: true
+---
+
+In addition to bacteria, we have processed archaea samples through the
+assembly pipeline and run checkm2. Metadata was downloaded from the ENA
+on 2024-07-31, getting all samples belonging to the taxon node 2157.
+There were 818 samples with WGS Illumina paired sequencing (ie the same
+rules we use for bacteria samples), resulting in 815 successful
+assemblies. These constitute archaea release 2024-07.
+
+The archaea files on OSF have the same format as for bacteria. The files
+are here: <https://osf.io/nehtp/>. The only exception is that, because
+there are relatively few samples, each release of assemblies consists of
+a single tarball of FASTA files (as opposed to 100s of tarballs).
+
+For a description of the files and metadata etc, please read the
+[Assemblies](/docs/assemblies/) and [batch downloading](/docs/osf_downloads/)
+pages.

--- a/content/docs/assemblies.md
+++ b/content/docs/assemblies.md
@@ -1,6 +1,6 @@
 ---
 title: Assemblies
-weight: 4
+weight: 50
 toc: true
 ---
 

--- a/content/docs/assemblies.md
+++ b/content/docs/assemblies.md
@@ -1,0 +1,192 @@
+---
+title: Assemblies
+weight: 4
+toc: true
+---
+
+## Summary
+
+Assemblies can be downloaded from OSF, AWS, or the ENA.
+
+- Batched assemblies are on OSF. If you want all assemblies or large
+  numbers then get them from OSF.
+- Individual FASTA files for each sample are on AWS. If you want
+  assemblies for specific samples then AWS will be easiest.
+- Individual FASTA files are also available from the ENA. However,
+  around 10,000 assemblies are not available from the ENA, since the
+  submission system rejected them due to various errors.
+
+## Downloading assemblies from AWS
+
+### Individual assembly files
+
+A gzipped FASTA assembly file for each sample is available, with the S3
+URI of the form:
+
+    s3://allthebacteria-assemblies/<SAMPLE_ID>.fa.gz
+
+For example:
+
+    s3://allthebacteria-assemblies/SAMD00000344.fa.gz
+
+To download to the current working directory using the aws cli:
+
+    aws s3 cp --no-sign-request s3://allthebacteria-assemblies/SAMD00000344.fa.gz .
+
+The object URL is of the form:
+
+    https://allthebacteria-assemblies.s3.eu-west-2.amazonaws.com/<SAMPLE_ID>.fa.gz
+
+For example:
+
+    https://allthebacteria-assemblies.s3.eu-west-2.amazonaws.com/SAMD00000344.fa.gz
+
+Download with wget:
+
+    wget https://allthebacteria-assemblies.s3.eu-west-2.amazonaws.com/SAMD00000344.fa.gz
+
+### List of all available assemblies
+
+If you want to know which assemblies are on AWS, we do not recommend
+running `ls` to find out! It will be slow. Every Monday, a list of
+current assembly files is generated. Get the latest file with:
+
+    aws s3 ls --no-sign-request s3://allthebacteria-metadata/allthebacteria-assemblies/assemblies-list/data/  | sort | tail -n1
+
+At the time of writing, the output was:
+
+    2025-03-23 17:38:59   79359181 b21b76f7-b5f1-4862-ba55-4b515bc6d05f.csv.gz
+
+That file can be downloaded to a file called `latest.tsv.gz` with:
+
+    aws s3 cp --no-sign-request s3://allthebacteria-metadata/allthebacteria-assemblies/assemblies-list/data/b21b76f7-b5f1-4862-ba55-4b515bc6d05f.csv.gz latest.tsv.gz
+
+or:
+
+    wget -O latest.tsv.gz https://allthebacteria-metadata.s3.eu-west-2.amazonaws.com/allthebacteria-assemblies/assemblies-list/data/b21b76f7-b5f1-4862-ba55-4b515bc6d05f.csv.gz
+
+That file lists all assemblies that are in the bucket
+`allthebacteria-metadata`, plus the size, md5sum, and time of upload.
+
+## Downloading assemblies from the ENA
+
+Nearly all of the assemblies have been accessioned in the ENA as
+"analysis" objects. The accessions are in the file
+`atb.metadata.202505.sqlite.assembly.tsv.xz`. It is a TSV format file of
+the table `assembly` from the
+[SQLite metadata database](/docs/metadata_sqlite/). The TSV file can be
+downloaded with:
+
+    wget -O atb.metadata.202505.sqlite.assembly.tsv.xz https://osf.io/download/4kjh7/
+
+The relevant columns here are `sample_accession` and
+`assembly_accession`. For example, sample `SAMN23010837` has the
+assembly accession `ERZ26049045`. Get the URL by querying the ENA:
+
+    $ wget -qO- 'https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERZ26049045&result=analysis'
+    analysis_accession  submitted_bytes submitted_md5   submitted_ftp
+    ERZ26049045 1785435 1e59b0bf2e684f6491d9617dee9fde2b    ftp.sra.ebi.ac.uk/vol1/analysis/ERZ260/ERZ26049045/SAMN23010837.fa.gz
+
+and then get the assembly with:
+
+    wget ftp.sra.ebi.ac.uk/vol1/analysis/ERZ260/ERZ26049045/SAMN23010837.fa.gz
+
+## Downloading assemblies from OSF
+
+FASTA files of assemblies for AllTheBacteria are available from OSF. To
+reduce file size, the assemblies are provided in batches of xzipped tar
+archives (made by [Miniphy](https://github.com/karel-brinda/MiniPhy)).
+Each archive contains up to ~4000 FASTA files.
+
+The downside of this is that if you want the assembly for a single
+sample, then you will need to download the tar.xz file and extract it
+from that. We apologise for the inconvenience, but bear in mind that
+miniphy compression makes a huge difference. For example, the size of
+the individual gzipped FASTA files for release 0.2 is around 3.1TB. This
+is too large to sensibly put on OSF. The total size of the same data but
+in compressed archive files is 89GB.
+
+The latest list of all samples and their related file names are in the
+file [file_list.all.latest.tsv.gz](https://osf.io/zxfmy/files/3xs6h).
+This file should have all the information you need. Older files and
+files split by dataset are also available - see the folder "File Lists"
+in the top level of the [Assembly component on
+OSF](https://osf.io/zxfmy/).
+
+The columns in this file are:
+
+- `sample` = the INSDC sample accession
+- `sylph_species` = inferred species call from running sylph on the
+  reads. This is using the "post-202505" method on *all* of the samples.
+  Meaning that species calls in files from 202505 onwards are not the
+  same as in files before 202505. See the [species calls](/docs/species_id/)
+  page for more details
+- `filename_in_tar_xz` = the FASTA filename for this sample inside the
+  tar.xz file
+- `tar_xz` = the name of the tar.xz file where this sample's FASTA lives
+- `tar_xz_url` = URL of `tar_xz`
+- `tar_xz_md5` = MD5 sum of `tar_xz`
+- `tar_xz_size_MB` = size of the `tar_xz`
+  file in MB
+
+Older files (pre-202505) have these two columns:
+
+- `species_sylph` = inferred species call from running sylph on the
+  reads, using the pre-202505 method.
+- `species_miniphy` = the name miniphy gave to the species
+
+If you want to download the archives in bulk, then use the `tar_xz_url`
+column to get the urls, and `tar_xz` for what you should name the
+downloaded file. OSF does not have the filename in the download URL.
+
+Here's an example of how to get the wget commands to run:
+
+    $ gunzip -c file_list.all.latest.tsv.gz | awk -F"\t" 'NR>1 {print "wget -O "$4" "$5}' | uniq | head -n3
+    wget -O atb.assembly.r0.2.batch.127.tar.xz https://osf.io/download/6671719165e1de5eb5893c28/
+    wget -O atb.assembly.r0.2.batch.136.tar.xz https://osf.io/download/66717ce2d835c439e94cdf1e/
+    wget -O atb.assembly.r0.2.batch.625.tar.xz https://osf.io/download/6672f5a7d835c43c944ce4e8/
+
+If you just want one sample, for example sample SAMD00000355, then this
+is the info in
+[file_list.all.latest.tsv.gz](https://osf.io/zxfmy/files/3xs6h):
+
+    sample              SAMD00000355
+    sylph_species       Streptococcus pyogenes
+    filename_in_tar_xz  atb.assembly.r0.2.batch.625/SAMD00000355.fa
+    tar_xz              atb.assembly.r0.2.batch.625.tar.xz
+    tar_xz_url          https://osf.io/download/6672f5a7d835c43c944ce4e8/
+    tar_xz_md5          444ff0fc9e860ab374bdc6fe9d9bd9f5
+    tar_xz_size_MB      21.5
+
+The wget command to get the tar file would be:
+
+    wget -O atb.assembly.r0.2.batch.625.tar.xz https://osf.io/download/6672f5a7d835c43c944ce4e8/
+
+Extract the FASTA with:
+
+    tar xf atb.assembly.r0.2.batch.625.tar.xz atb.assembly.r0.2.batch.625/SAMD00000355.fa
+
+## Species calls and assembly batches
+
+The text below only applies to 2024-08 and earlier. It is only relevant
+if you are using old files. For 2025-05, there is only one species call
+in the assembly file, which is made from parsing sylph results as
+described [here](/docs/species_id/).
+
+Why are species calls included in the assembly file? For convenience, to
+allow getting all assemblies for a particular species. Note that one
+batch of assemblies will often contain the same species.
+
+Miniphy needs species calls to aid compression of the assembly FASTA
+files, so that similar genomes are batched together. We run Sylph on all
+reads, to get this species call for each sample. See the
+[Sylph section](/docs/species_id/) of the species page for details. The calls
+input to Miniphy are in the column `species_sylph`. Miniphy changes
+these names (removing spaces, adding underscores) - we put the Miniphy
+name in `species_miniphy` column.
+
+Miniphy keeps its species names in its output files. However, for
+AllTheBacteria we want to keep species calls separate from assembly
+files. For this reason, we rename the miniphy files before releasing
+them. (Side note: release 0.2 on the EBI FTP site did have species names
+in them, but were removed while [migrating to OSF](/docs/ebi2osf/).)

--- a/content/docs/bgcs.md
+++ b/content/docs/bgcs.md
@@ -1,0 +1,30 @@
+---
+title: Biosynthetic gene clusters
+weight: 9
+toc: true
+---
+
+## GECCO
+
+The biosynthetic gene clusters (BGCs) detected by running GECCO (v0.9.8)
+on AllTheBacteria v0.2 and the incremental release (08-2024) are
+available on [OSF](https://osf.io/cufb2/). The results include
+concatenated files of BGCs as GenBank records (`.gbk`) as well as the
+concatenated `clusters.tsv` files with associated information. Due to
+file size, the `.gbk` files have been split (3 files for v0.2 and 2 for
+the incremental release 08-2024). For further details on what the
+`clusters.tsv` files contain, please see the [GECCO
+documentation](https://gecco.embl.de). We have provided separate files
+for the v0.2 release and the incremental release (08-2024), as well as a
+pair of files which contains both the v0.2 and the incremental release
+(08-2024).
+
+Also available is a status file indicating which genomes (`samples`
+column) have been processed. As of now, that includes all genomes
+present in release v0.2 and in the incremental release (08-2024), and
+hence all samples are marked as `PASS` in the second column (`status`).
+
+GECCO v0.9.8 was run as a container, which is available on
+Biocontainers. All scripts used for the analysis are provided on the
+AllTheBacteria GitHub (add link here). For any questions, please contact
+[Laura Carroll](mailto:laura.carroll@umu.se).

--- a/content/docs/bgcs.md
+++ b/content/docs/bgcs.md
@@ -1,6 +1,6 @@
 ---
 title: Biosynthetic gene clusters
-weight: 9
+weight: 100
 toc: true
 ---
 

--- a/content/docs/contributing.md
+++ b/content/docs/contributing.md
@@ -1,0 +1,207 @@
+---
+title: Contributing to AllTheBacteria
+weight: 14
+toc: true
+---
+
+We welcome contributions to AllTheBacteria. Please read on for
+instructions on how to contribute to the project.
+
+## Background information
+
+Where do all the files live?
+
+- Assemblies, metadata and all analysis files are hosted at the
+  AllTheBacteria project on OSF: <https://osf.io/xv7q9/>. ie this is
+  where we expect users of the data to go.
+- Files to reproduce the analyses (scripts, methods descriptions) are on
+  the AllTheBacteria GitHub repository:
+  <https://github.com/AllTheBacteria/AllTheBacteria>. This is where
+  contributors should add their reproducibility files, and where anyone
+  should look for methods as opposed to the actual data. The exception
+  is large files (eg containers or databases), which go on OSF.
+- Documentation for the end-user (ie how can I get and use the data?) is
+  here on readthedocs.
+
+### Before starting
+
+Before starting any work that you intend to contribute, please check if
+it has already been done (it’s already on the OSF AllTheBacteria
+project) or is already on the to do/in progress list (see the
+[AllTheBacteria GitHub planning
+project](https://github.com/orgs/AllTheBacteria/projects/1/views/1)).
+
+Every task on the project page should link to a GitHub issue. If the
+work you are interested in is already in progress and you want to
+comment and/or help, then please reply to the relevant existing GitHub
+issue.
+
+To contribute, you will need:
+
+- A [GitHub](https://github.com) account
+- An [OSF](https://osf.io) account
+
+## Making your analyses reproducible
+
+Please consider reproducibility before running any analysis.
+
+Methods and scripts should be ultimately added to the public
+AllTheBacteria GitHub repository. At a minimum, this means anyone should
+be able to figure out exactly what you ran (tool versions, commands etc)
+and have access to any scripts that were used. If not already publicly
+available, we will insist that any containers used are added to OSF.
+
+We understand that everyone works differently. It is perfectly
+reasonable to make a script/pipeline that you used to run on your own
+compute cluster, knowing that it would likely break if someone else
+tried running it elsewhere. We just require that all scripts are made
+available, so that the process is clearly documented, even though it is
+not necessarily easy to rerun. For a concrete example see the [checkm2
+analysis](https://github.com/AllTheBacteria/AllTheBacteria/tree/main/reproducibility/All-samples/checkm2),
+which was run on the EBI cluster using SLURM. Alternateively, if you
+have bandwidth, please ask the community (via email or the MicroBio
+Slack channel) whether anyone is willing to help you make it
+reproducible.
+
+## SOP for contributing
+
+Please note that this is a general standard operating procedure (SOP)
+intended to cover most cases. However, every analysis is different.
+Please ask or suggest something different if it makes sense to do so for
+your analysis. The overall aim is to make it as easy as we can for users
+to download the results from OSF, and the methods/reproducibility to be
+documented as clearly and comprehensively as possible.
+
+### Register your planned work on GitHub
+
+First, make a new [AllTheBacteria GitHub
+issue](https://github.com/AllTheBacteria/AllTheBacteria/issues)
+describing what you intend to do. This should get picked up by one of
+the admins, who will:
+
+- agree that the analysis can be added to AllTheBacteria
+- add a new piece of work in the to-do column of the [AllTheBacteria
+  GitHub
+  project](https://github.com/orgs/AllTheBacteria/projects/1/views/1),
+  linked to the GitHub issue you created.
+- Reply to the issue with the link to an OSF project component, which is
+  where the final analysis files will be shared.
+
+You will need to give us your OSF account ID, so we can add you to the
+new OSF project component. The ID can be found by logging into OSF,
+clicking on your name in the top right and choosing "My profile". At the
+top right of your profile page is a URL, for example
+<https://osf.io/wxcdj/>. This is what we need to add you to the project
+component, giving permission to add files.
+
+### Carry out the analysis
+
+Run your analysis, but please bear in mind reproducibility and ease of
+use of the output files. Essentially, please be sensible, imagine you
+are the end-user of your data and think about the format that you would
+want it in.
+
+Please:
+
+- Take note of all commands that were run and software versions. This
+  information can be added to the reproducibility files on Github later.
+- Track all samples using the SAM\* accession.
+- Keep track of which samples/releases you ran on. At the time of
+  writing there is release 0.2 plus incremental release 2024-08.
+- We will require a "status" file that lists each sample and a result of
+  "PASS", "FAIL", "NOT DONE", so that users can easily find out the
+  overall state of any sample with respect to your analysis.
+- Where possible, keep raw output from tools, but concatenate files into
+  one output file instead of sharing millions files. But make sure the
+  samples and their results are identifiable. For example, if the file
+  is csv/tsv, then add a Sample column and fill this with the SAM\*
+  accession.
+- Compress final files with gzip or xz (with the -9 option for maximum
+  compression).
+- Where possible and it makes sense to do so, keep the number of files
+  and total size to a minimum.
+
+### Add files to OSF
+
+You should have been given access to an OSF project component, where you
+can upload results files. Please include an overall "status" file (as
+described above) together will all the other results.
+
+OSF has a file size limit of 5GB, and a project component limit of 50GB.
+We can work around the 50GB limit by batching files over more than one
+component. Request this on your GitHub issue if it is needed and we can
+create more components. For example, see the [assembly
+files](https://osf.io/zxfmy/), which are split over two components.
+
+If possible, please organise the files inside the component by having
+top-level folders named with the version number of the tool that was
+run. Inside there, have a folder of each batch of data the analysis was
+run on (for example, release 0.2, incremental release 2024-08), and also
+a folder that has all results aggregated together, so it is easy for the
+user to get them. This of course may depend on your analysis, for
+example the [AMRfinderPlus results](https://osf.io/7nwrx/) have an extra
+layer of versions because there is the tool version, but also the
+version of the reference database that was used.
+
+The intention is that reproducibility files are kept on GitHub, however
+some files will be too big. Please note:
+
+- If you used a container that is not publicly available (eg
+  biocontainers or similar), then add the file to OSF inside a folder
+  called “reproducibility”. For singularity, upload the image file. For
+  docker, archive the container with `docker save foo > bar.tar` and put
+  the archive on OSF.
+- Any other “big” files (ie too big to be sensible for git) that were
+  used as part of running the analysis should also be uploaded to OSF.
+  Unless they are far too big and can be obtained elsewhere (eg the
+  AMRFinderplus database is small, but the Bakta database is huge).
+
+### GitHub pull request
+
+Please send a pull request to the [AllTheBacteria github
+repository](https://github.com/AllTheBacteria/AllTheBacteria) that:
+
+1.  refers to the GitHub issue related to the analysis (the issue you
+    originally made),
+2.  adds documentation to readthedocs, and
+3.  includes reproducibility files.
+
+Notes on the documentation:
+
+- this should be instructions for any user who will want to download
+  your analysis files and use them.
+- The documentation is in the `docs/` folder.
+- If you are adding a new page, then this means adding a new `.rst` file
+  and adding its name (without the `.rst`) to the `toctree` section of
+  the index file `index.rst`. For example, if the new file is `foo.rst`,
+  then also add `foo` to the index file.
+- The title that is in the `foo.rst` file - defined by the first line of
+  the file followed by a line of `====` of the same length - is what
+  will appear in the contents panel on the left of the readthedocs
+  pages. Please name this sensibly.
+- The order of files in the `index.rst` file is the same as the order
+  that is shown in readthedocs. If you add a new file, please put it in
+  an order that seems sensible.
+- You can build a local copy of the documentation by running
+  `sphinx-build -b html -d _build/doctrees . OUT/html`. This assumes
+  that sphinx is installed (on Ubuntu the package is `python3-sphinx`),
+  and also the python package `sphinx_rtd_theme` (which is pip
+  installable)
+- when the pull request is merged, readthedocs at
+  <https://allthebacteria.readthedocs.io/en/latest/> will be
+  automatically rebuilt with the changes.
+
+Notes on reproducibility files:
+
+- Please add a new directory that contains all of your new files. If it
+  is across all species, then put it in `reproducibility/All-samples/`,
+  otherwise put it in `reproducibility/Species-specific/`.
+- Include a `README.md` file that describes the analysis and/or methods.
+  In particular, commands run and software versions etc.
+- Include all scripts that were run. If things are hard-coded or in
+  other ways specific to how/where you ran, making them hard to run for
+  others, please note this in the README.
+
+In addition to checking the GitHub files in the pull request, the files
+added to OSF will also be checked. Once the PR is accepted, that is also
+saying that we are happy with the changes to both GitHub and OSF.

--- a/content/docs/contributing.md
+++ b/content/docs/contributing.md
@@ -21,7 +21,7 @@ Where do all the files live?
   should look for methods as opposed to the actual data. The exception
   is large files (eg containers or databases), which go on OSF.
 - Documentation for the end-user (ie how can I get and use the data?) is
-  here on readthedocs.
+  on this website under [/docs/](/docs/).
 
 ### Before starting
 
@@ -163,7 +163,7 @@ repository](https://github.com/AllTheBacteria/AllTheBacteria) that:
 
 1.  refers to the GitHub issue related to the analysis (the issue you
     originally made),
-2.  adds documentation to readthedocs, and
+2.  adds documentation to this website under `content/docs/`, and
 3.  includes reproducibility files.
 
 Notes on the documentation:
@@ -171,25 +171,18 @@ Notes on the documentation:
 - this should be instructions for any user who will want to download
   your analysis files and use them.
 - The documentation is in the `docs/` folder.
-- If you are adding a new page, then this means adding a new `.rst` file
-  and adding its name (without the `.rst`) to the `toctree` section of
-  the index file `index.rst`. For example, if the new file is `foo.rst`,
-  then also add `foo` to the index file.
-- The title that is in the `foo.rst` file - defined by the first line of
-  the file followed by a line of `====` of the same length - is what
-  will appear in the contents panel on the left of the readthedocs
-  pages. Please name this sensibly.
-- The order of files in the `index.rst` file is the same as the order
-  that is shown in readthedocs. If you add a new file, please put it in
-  an order that seems sensible.
+- If you are adding a new page, add a new Markdown file in
+  `content/docs/`, with Hugo front matter including `title`, `weight`,
+  and `toc`. For example, a new page might be `content/docs/foo.md`.
+- The page `title` is what will appear in the docs navigation. Please
+  name this sensibly.
+- The `weight` in the front matter controls the order shown in the docs
+  navigation. If you add a new file, give it a weight that keeps the
+  section order sensible.
 - You can build a local copy of the documentation by running
-  `sphinx-build -b html -d _build/doctrees . OUT/html`. This assumes
-  that sphinx is installed (on Ubuntu the package is `python3-sphinx`),
-  and also the python package `sphinx_rtd_theme` (which is pip
-  installable)
-- when the pull request is merged, readthedocs at
-  <https://allthebacteria.readthedocs.io/en/latest/> will be
-  automatically rebuilt with the changes.
+  `hugo`, or preview it locally with `hugo server`.
+- when the pull request is merged, this website will need to be
+  rebuilt/deployed with the changes.
 
 Notes on reproducibility files:
 

--- a/content/docs/contributing.md
+++ b/content/docs/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing to AllTheBacteria
-weight: 14
+weight: 150
 toc: true
 ---
 
@@ -156,33 +156,45 @@ some files will be too big. Please note:
   Unless they are far too big and can be obtained elsewhere (eg the
   AMRFinderplus database is small, but the Bakta database is huge).
 
-### GitHub pull request
+### GitHub pull requests
 
-Please send a pull request to the [AllTheBacteria github
-repository](https://github.com/AllTheBacteria/AllTheBacteria) that:
+Please send two pull requests:
 
-1.  refers to the GitHub issue related to the analysis (the issue you
-    originally made),
-2.  adds documentation to this website under `content/docs/`, and
-3.  includes reproducibility files.
+1.  A pull request to the [AllTheBacteria GitHub
+    repository](https://github.com/AllTheBacteria/AllTheBacteria) that:
+
+    - refers to the GitHub issue related to the analysis (the issue you
+      originally made)
+    - includes reproducibility files
+
+2.  A separate pull request to the [ATB_website GitHub
+    repository](https://github.com/AllTheBacteria/ATB_website) that:
+
+    - adds or updates the end-user documentation for your analysis
 
 Notes on the documentation:
 
 - this should be instructions for any user who will want to download
   your analysis files and use them.
-- The documentation is in the `docs/` folder.
+- The documentation is in the `content/docs/` folder of the
+  `ATB_website` repository.
 - If you are adding a new page, add a new Markdown file in
   `content/docs/`, with Hugo front matter including `title`, `weight`,
-  and `toc`. For example, a new page might be `content/docs/foo.md`.
+  and `toc`. Here, `weight` is used for page ordering in the docs
+  navigation, not font styling. For example, a new page might be
+  `content/docs/foo.md`.
 - The page `title` is what will appear in the docs navigation. Please
   name this sensibly.
 - The `weight` in the front matter controls the order shown in the docs
   navigation. If you add a new file, give it a weight that keeps the
-  section order sensible.
+  section order sensible. We currently use gaps such as 10, 20, 30, so
+  you do not have to renumber every page: for example, inserting a page
+  at 15 between 10 and 20 makes later additions easier.
 - You can build a local copy of the documentation by running
   `hugo`, or preview it locally with `hugo server`.
-- when the pull request is merged, this website will need to be
-  rebuilt/deployed with the changes.
+- documentation changes should be reviewed and merged via a pull request
+  to `ATB_website`, separately from the analysis/reproducibility pull
+  request to `AllTheBacteria`.
 
 Notes on reproducibility files:
 
@@ -195,6 +207,7 @@ Notes on reproducibility files:
   other ways specific to how/where you ran, making them hard to run for
   others, please note this in the README.
 
-In addition to checking the GitHub files in the pull request, the files
-added to OSF will also be checked. Once the PR is accepted, that is also
-saying that we are happy with the changes to both GitHub and OSF.
+In addition to checking the GitHub files in the pull requests, the files
+added to OSF will also be checked. Once the PRs are accepted, that is
+also saying that we are happy with the changes to GitHub, the website,
+and OSF.

--- a/content/docs/defense.md
+++ b/content/docs/defense.md
@@ -1,6 +1,6 @@
 ---
 title: Defense systems
-weight: 8
+weight: 90
 toc: true
 ---
 

--- a/content/docs/defense.md
+++ b/content/docs/defense.md
@@ -1,0 +1,39 @@
+---
+title: Defense systems
+weight: 8
+toc: true
+---
+
+The results of running DefenseFinder v1.3.0 on all Enterobacterales
+species with \>400 samples from release 0.2 plus incremental release
+2024-08 are available on OSF in the [DefenseFinder
+component](https://osf.io/hpgac/overview). This includes 27 species and
+1,166,956 samples.
+
+Note that this analysis is all with DefenseFinder
+[v1.3.0](https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0)
+using the profiles from defense-finder-models v1.3.0 and CasFinder
+v3.1.0. This means that defense systems added to DefenseFinder after
+July 2024 will not be present in the results. the time of writing
+(February 2026) the latest release of DefenseFinder is v2.0.1
+
+We have shared a single results file which is the concatenated output of
+the `systems.tsv` file from all individual
+DefenseFinder runs. The status file indicates which samples we ran the
+analysis on with `PASS` if the run completed successfully. There are
+n=653 samples where no defense system was detected in the assembly, so
+these samples are absent from the results file but coded as `PASS` in
+the status file.
+
+**Important:** Note that this analysis is all with DefenseFinder
+[v1.3.0](https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0)
+using the profiles from CasFinder v3.1.0 and defense-finder-models
+v1.3.0, the latter of which includes 151 defense systems (and 16
+anti-defense systems). This means that newer defense systems added to
+DefenseFinder after July 2024 will not be present in the results. For
+context, as of February 2026 the latest release of DefenseFinder is
+v2.0.1 and the latest models version (v2.0.2) contains 262 defense
+systems.
+
+More details on the analysis are available on the AllTheBacteria github
+[here](https://github.com/AllTheBacteria/AllTheBacteria/tree/main/reproducibility/All-samples/defense-systems).

--- a/content/docs/ebi2osf.md
+++ b/content/docs/ebi2osf.md
@@ -1,6 +1,6 @@
 ---
 title: Migration from EBI FTP to OSF
-weight: 18
+weight: 190
 toc: true
 ---
 

--- a/content/docs/ebi2osf.md
+++ b/content/docs/ebi2osf.md
@@ -1,0 +1,142 @@
+---
+title: Migration from EBI FTP to OSF
+weight: 18
+toc: true
+---
+
+This page has details of moving the data originally hosted at the [EBI
+FTP site](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/) to OSF.
+You probably only want to read this if you used data that was on the FTP
+site, and are now looking at the AllTheBacteria project on OSF and want
+to know why some file names have changed. The short explanation is: file
+names were changed so that they did not have species names in them.
+
+## Spare me the details, I just want old -\> new names
+
+Assembly tarballs and Phylign index files were renamed. Here is a TSV
+file that has all the old and new file names, md5 sums, and OSF URLs:
+[atb_ebi_r0.2_ftp_to_osf_rename.tsv](https://osf.io/jkg72). No other
+filenames were changed.
+
+## What was/is on the EBI FTP site?
+
+There was:
+
+- [release
+  0.1](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.1/).
+  This was the first release of the data, and corresponds to the first
+  version of the
+  [preprint](https://www.biorxiv.org/content/10.1101/2024.03.08.584059v1).
+  The data have since been withdrawn and replaced by version 0.2.
+
+There is:
+
+- [release
+  0.2](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/).
+  This is the second release of the data, which is the same as 0.1 but
+  with some human contamination contigs removed.
+
+See the [release history](/docs/release_history/) for more details on
+releases 0.1 and 0.2. Everything below is describing release 0.2 and
+what happened during copying from the FTP site to OSF.
+
+## What is on OSF?
+
+All data from release 0.2 are also on OSF. However, some files were
+renamed before putting on OSF, so that no species names were in the file
+names. We wanted to separate out species calls from the assemblies
+themselves. The assemblies will not (or are extremely unlikely to)
+change. Species calling is difficult, and we do expect that to change.
+
+Why were species names in the files? Because the compression/indexing
+processes needed species calls. It doesn't matter if those calls are
+wrong, it just helps to group similar genomes together for compression
+efficiency. However, leaving those species names in the file names could
+be misleading, especially as species calls will change over time.
+
+## Metadata files
+
+These files are all the same. All files in the [ftp metadata
+directory](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/metadata/)
+were copied to OSF, in the [AllTheBacteria metadata
+component](https://osf.io/h7wzy/). Some files may get added to OSF, but
+all files on FTP were copied over to OSF.
+
+## Assembly files
+
+No actual assemblies were changed. All FASTA files are identical between
+the EBI ftp site and on OSF. However, the assembly tarball names, and
+the directory name that each tarball extracts to, was changed.
+
+This should make sense using an example. This tarball is on the FTP
+site: `achromobacter_xylosoxidans__01.asm.tar.xz`. It extracts to a
+directory `achromobacter_xylosoxidans__01/` containing FASTA files. In
+other words, running `tar xf achromobacter_xylosoxidans__01.asm.tar.xz`
+would make these files:
+
+    achromobacter_xylosoxidans__01/SAMN12335635.fa
+    achromobacter_xylosoxidans__01/SAMN12335634.fa
+    achromobacter_xylosoxidans__01/SAMN12335574.fa
+    ...etc
+
+The renamed tarball on OSF is called `atb.assembly.r0.2.batch.1.tar.xz`
+and it extracts to the directory `atb.assembly.r0.2.batch.1/`. In other
+words, running `tar xf atb.assembly.r0.2.batch.1.tar.xz` would make
+these files:
+
+    atb.assembly.r0.2.batch.1/SAMN12335635.fa
+    atb.assembly.r0.2.batch.1/SAMN12335634.fa
+    atb.assembly.r0.2.batch.1/SAMN12335574.fa
+    ...etc
+
+The extracted files `SAMN12335635.fa`, `SAMN12335634.fa`,
+`SAMN12335574.fa`, ... are identical bewteen the original and renamed
+tarballs. The only difference is the tarball name and directory to which
+it extracts. The order of the files inside each tarball was preserved.
+
+## Index files
+
+### Sketchlib
+
+The [sketchlib files on the FTP
+site](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/indexes/sketchlib/)
+were copied with no changes to the OSF [AllTheBacteria sketchlib
+component](https://osf.io/rceq5/).
+
+### Phylign
+
+The [Phylign files on the FTP
+site](https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/indexes/phylign/)
+were renamed on the OSF [AllTheBacteria Phylign
+component](https://osf.io/h6xk7/). The renaming was done to match the
+assembly renaming. For example, the file
+`achromobacter_xylosoxidans__01.cobs_classic.xz` on the FTP site was
+renamed to `atb.assembly.r0.2.batch.1.cobs_classic.xz` on OSF.
+
+## Are 15 Phylign files missing?
+
+No.
+
+You may have noticed that the numbering in the phylign files jumps from
+file `atb.assembly.r0.2.batch.637.cobs_classic.xz` to
+`atb.assembly.r0.2.batch.653.cobs_classic.xz`. There are no 638-652
+phylign files. Why is this...?
+
+When renaming the assembly and phylign files, the old names were just
+enumerated, so the first file
+`achromobacter_xylosoxidans__01.asm.tar.xz` was renamed
+`atb.assembly.r0.2.batch.1.tar.xz`. And similarly, the corresponding
+Phylign old file was `achromobacter_xylosoxidans__01.cobs_classic.xz`,
+and renamed to `atb.assembly.r0.2.batch.1.cobs_classic.xz`.
+
+The samples with no species call are spread across 15 assembly tarballs
+(old name `unknown__01.asm.tar.xz` ... `unknown__15.asm.tar.xz`), and
+got new names `atb.assembly.r0.2.batch.638.tar.xz` ...
+`atb.assembly.r0.2.batch.652.tar.xz`. These samples were not included in
+the Phylign index. To keep the numbering consistent when translating:
+old assembly tarball \<-\> old Phylign \<-\> new assembly tarball \<-\>
+new Phylign file, we left out new Phylign file numbers 638-652. This
+means that the filename numbering for assemblies and Phylign file is
+consistent and assembly batch number `N`
+(`atb.assembly.r0.2.batch.N.tar.xz`) corresponds to Phylign index file
+number `N` (`atb.assembly.r0.2.batch.N.cobs_classic.xz`).

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-weight: 16
+weight: 170
 toc: true
 ---
 

--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -1,0 +1,31 @@
+---
+title: FAQ
+weight: 16
+toc: true
+---
+
+## Can I freely use the data?
+
+Anyone/everyone is welcome to use the data and publish with them. There
+is no expectation that the people who made the release/data should be
+co-authors on these publications, but we would appreciate citation of
+the preprint
+(<https://www.biorxiv.org/content/10.1101/2024.03.08.584059v1>).
+
+## How can I get involved?
+
+All are welcome. Contact us via Github, Slack or the monthly zoom calls.
+Anyone who contributes to the project, through analysis, project
+management or any other means, ought to be an author of the paper.
+
+## What happens if two people want to run their competing methods?
+
+(Bad example, prokka versus bakta or one AMR tool versus another).
+First, anyone can do anything they like, but to get into the releases,
+we should discuss on a zoom call and make a decision. We shall tend
+towards allowing multiple analyses (eg we intend to run bakta on
+everything but if someone wants to run prokka too, we should we ok to
+add that to the release too). However, if it starts to get silly with
+people wanting 4 tools each run with 3 parameters, then I think we get a
+lot stricter - this compute isn't free (in terms of carbon, or money),
+so we'll make a decision and do something limited.

--- a/content/docs/hypothetical_protein_structures.md
+++ b/content/docs/hypothetical_protein_structures.md
@@ -1,6 +1,6 @@
 ---
 title: Hypothetical protein structures
-weight: 10
+weight: 110
 toc: true
 ---
 

--- a/content/docs/hypothetical_protein_structures.md
+++ b/content/docs/hypothetical_protein_structures.md
@@ -1,0 +1,165 @@
+---
+title: Hypothetical protein structures
+weight: 10
+toc: true
+---
+
+**Note: All structures available here have been integrated into the
+AlphaFold Database.**
+
+For more detailed visual analysis and downloads, please see
+<https://alphafold.ebi.ac.uk>
+
+You cannot search the AFDB using the ATB/Bakta locus tags - see below
+for more information on how to map the ATB/Bakta tags to AFDB
+accessions.
+
+## Preprocessing
+
+Note: All `.pdb` files in this dataset use the locus_tag from Bakta,
+which contains the SRA accession before the '.' delimited e.g.
+`SAMEA7561354.JGMNBG_20630` comes from SRA accession SAMEA7561354.
+
+To begin: all `275,945,762` hypothetical proteins from the Bakta
+annotations were taken.
+
+Then, only proteins belonging to genomes passing QC (i.e. PASS) from
+`Aggregated/work_in_progress_2025-05/species_calls.tsv.gz`
+[here](https://osf.io/h7wzy/files/osfstorage) were filtered to
+prioritise highly confident genome assemblies and protein calls.
+
+This left `224,184,215` proteins remaining for downstream consideration.
+
+These were combined and deduplicated at 100% seqid over 100% sequence
+length.
+
+Then, this set was filtered to keep only proteins below 3000AA, due to
+VRAM limitations of available GPUs for folding.
+
+We have not released the additional longer proteins (work in progress,
+contact George Bouras if interested).
+
+Overall, this left `17,711,165` unique proteins.
+
+## Taxonomy
+
+We used the sylph species predictions from
+`Aggregated/work_in_progress_2025-05/species_calls.tsv.gz`. These were
+generated using the GTDB GTDB 214.0 release (28 April 2023 database).
+
+We also mapped these to NCBI taxids using the `bac120_metadata_r214.tsv`
+and `ar53_metadata_r214.tsv` release from GTDB 214.
+
+The NCBI taxonomy calls are what you will see in AlphaFold Database.
+
+## Predictions
+
+Multiple sequence alignments were generated in chunks of 250,000
+proteins using ColabFold v1.5.5 using MMseqs2 version `15.6f452` with
+the `colabfold_search` command. The default parameters and databases
+(`uniref30_2302` and `colabfold_envdb_202108` ) were used.
+
+Each AlphaFold2 implemented via ColabFold v1.5.5 was then run with each
+MSA as input using `colabfold_batch` with ptm model 1 only
+(`--num-models 1`) for maximum throughput, using otherwise the default
+parameters ( 3 recycles, no templates or relaxation ).
+
+All predictions were conducted on AMD MI250x GPUs on Setonix at the
+Pawsey Supercomputing Research Centre in Perth, Australia using the
+specific container tag `rocm6_cpuTF` available at
+<https://quay.io/repository/sarahbeecroft9/colabfold?tab=tags>.
+
+## Files
+
+### Foldseek Database
+
+We provide a Foldseek database (created using `foldseek createdb`) via
+OSF (<https://osf.io/x693m/overview>) in the `Foldseek_Databases`
+component.
+
+Note that due to the size restrictions on individual file, it was split
+into 1GB parts for OSF
+
+To remake it:
+`cat foldseek_db.tar.gz_parta* > foldseek_db.tar.gz && tar -xzf foldseek_db.tar.gz`
+
+### Foldcomp Database
+
+We provide a Foldcomp database (created using `foldseek createdb`) via
+OSF (<https://osf.io/x693m/overview>) in the `Foldcomp_Databases`
+component.
+
+Note that due to the size restrictions on individual file, it was split
+into 1GB parts for OSF
+
+To remake it:
+`cat foldcomp_db.tar.gz_parta* > foldcomp_db.tar.gz && tar -xzf foldcomp_db.tar.gz`
+
+### Predictions
+
+If you want to full, non-lossy compressed predictions, we provide `.pdb`
+format structures via OSF.
+
+Hosting other AF2 output files (MSAs, pLDDT and PAE `.json` confidence
+metrics) take many many TBs of storage and are beyond our capacity to
+host on OSF. These can be accessed via <https://alphafold.ebi.ac.uk>
+
+All `.pdb` files are batched into 142 batches `.tar.gz` files at
+<https://osf.io/x693m/overview>.
+
+Each `.tar.gz` file contains the subdirectories with the SRA accessions
+of each protein in the batch. The `.pdb` files are then nested inside
+the subdirectories.
+
+These are themselves in 9 Sets. Each Set contains 16 batches other than
+Set 9 which contains 14.
+
+## FASTA
+
+The FASTA component contains all `275,945,762` unfiltered hypothetical
+proteins in FASTA format.
+
+Note: you will also need to put it back together
+`cat all_hypotheticals_under_3000AA_unfiltered.fastq.gz_part* > all_hypotheticals_under_3000AA_unfiltered.fastq.gz_part.gz`
+
+### Metadata
+
+To map between the ATB (i.e. Bakta with SRA accession) locus tags, the
+AlphaFold Database tags and the batch tarball (above), please see
+`ATB_AFDB_map_with_batches.tsv.gz`
+
+This provides a 3 column tsv file that maps the ATB/Bakta locus tag
+(column 1) to the AlphaFold database accession 16 digit code (column 2)
+OSF batch (column 3).
+
+e.g.
+
+``` bash
+head -n1 ATB_hypothetical_protein_structures_batch.tsv
+SAMEA7561354.JGMNBG_20630   0000000000710001    batch001
+```
+
+- The AFDB accession will be AF-0000000000710001-v1 e.g see
+  <https://alphafold.ebi.ac.uk/entry/AF-0000000000710001>
+
+We also provide the representative protein (i.e. - what actually ended
+up being folded) , sylph GTDB and mapped NCBI species calls for all
+`224,184,215` member proteins before deduplication.
+
+This provides a 5 column tsv file
+`ATB_every_protein_with_species.tsv.gz` with the representative (column
+1), member (column 2), sylph GTDB species name of the member (column 3),
+mapped NCBI taxonomy species name (column 4) and NCBI taxid (column 5)
+
+e.g.
+
+``` bash
+head -n1 ATB_every_protein_with_species.tsv
+SAMEA7561354.JGMNBG_20625   SAMEA7561354.JGMNBG_20625   Mycobacterium tuberculosis  Mycobacterium tuberculosis H37R 83332
+```
+
+Note: you will also need to put it back together
+`cat ATB_every_protein_with_species.tsv.gz_parta* > ATB_every_protein_with_species.gz`
+
+For any questions regarding the protein structure predictions, please
+contact George Bouras <george.bouras@adelaide.edu.au>

--- a/content/docs/lexicmap.md
+++ b/content/docs/lexicmap.md
@@ -1,0 +1,240 @@
+---
+title: Sequence alignment with LexicMap
+weight: 13
+toc: true
+---
+
+[LexicMap](https://github.com/shenwei356/LexicMap) is a nucleotide
+sequence alignment tool for efficiently querying gene, plasmid, viral,
+or long-read sequences (\>100bp) against up to millions of prokaryotic
+genomes.
+
+There are three ways to perform sequence alignment on AllTheBacteria
+assemblies with LexicMap:
+
+- [Searching on AWS EC2](#searching-on-aws-ec2) - Use the pre-built index hosted on AWS
+- [Local search with pre-built index](#local-search-with-pre-built-index) - Download the index from AWS and search locally
+- [Building an index and searching locally](#building-an-index-and-searching-locally) - Download assemblies from OSF and build an index
+
+## Searching on AWS EC2 {#searching-on-aws-ec2}
+
+1.  [Launch an EC2
+    instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/LaunchingAndUsingInstances.html)
+    **in Europe London region (eu-west-2)** where the index is located.
+
+    - OS: Amazon Linux 2023 64-bit (**Arm**)
+    - Instance type (You might need to [increase the limit of
+      CPUs](http://aws.amazon.com/contact-us/ec2-request)):
+      - c7g.8xlarge (32 vCPU, 64 GiB memory, 15 Gigabit, 1.3738 USD per
+        Hour)
+      - c6gn.12xlarge (48 vCPU, 96 GiB memory, 75 Gigabit, 2.46 USD per
+        Hour) (**recommended**)
+    - Storage: 20 GiB General purpose (gp3), only for storing queries
+      and results.
+
+2.  [Connect to the instance via online console or a ssh
+    client](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect.html).
+
+3.  Mount the LexicMap index with
+    [mount-s3](https://github.com/awslabs/mountpoint-s3) (it’s fast but
+    still slower than local disks).
+
+        # Install mount-s3. You might need to replace arm64 with x86_64 for other architectures
+        wget https://s3.amazonaws.com/mountpoint-s3-release/latest/arm64/mount-s3.rpm
+        sudo yum install -y ./mount-s3.rpm
+        rm ./mount-s3.rpm
+
+        # Mount the v0.2+202408 index
+        mkdir -p atb.lmi
+        UNSTABLE_MOUNTPOINT_MAX_PREFETCH_WINDOW_SIZE=65536 \
+            mount-s3 --read-only --prefix 202408/ allthebacteria-lexicmap atb.lmi --no-sign-request
+
+4.  Install LexicMap.
+
+        # Check the latest version here: https://github.com/shenwei356/LexicMap/releases
+        # You can also check the pre-release here: https://github.com/shenwei356/LexicMap/issues/10
+        # Binary's path depends on the architecture of the CPUs: amd64 or arm64
+        wget https://github.com/shenwei356/LexicMap/releases/download/v0.7.0/lexicmap_linux_arm64.tar.gz
+
+        mkdir -p bin
+        tar -zxvf lexicmap_linux_arm64.tar.gz -C bin
+        rm lexicmap_linux_arm64.tar.gz
+
+5.  [Upload
+    queries](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/linux-file-transfer-scp.html).
+
+        # Here, we use a demo query
+        wget https://github.com/shenwei356/LexicMap/raw/refs/heads/main/demo/bench/b.gene_E_faecalis_SecY.fasta
+
+6.  Run LexicMap
+    ([tutorial](https://bioinf.shenwei.me/LexicMap/tutorials/search/)).
+
+        # Create and enter a screen session
+        screen -S lexicmap
+
+        # Run
+        #   Searching with b.gene_E_faecalis_SecY.fasta takes 20 minutes with c7g.8xlarge, 12.5 minutes with c6gn.12xlarge
+        #   Searching with b.gene_E_coli_16S.fasta      takes 1h54m with c6gn.12xlarge.
+        lexicmap search -d atb.lmi b.gene_E_faecalis_SecY.fasta -o query.lexicmap.txt.gz --debug
+
+7.  Unmount the index.
+
+        sudo umount atb.lmi
+
+## Local search with pre-built index {#local-search-with-pre-built-index}
+
+Install `awscli` via conda.
+
+    conda install -c conda-forge awscli
+
+Test access.
+
+    aws s3 ls s3://allthebacteria-lexicmap/202408/ --no-sign-request
+
+    # output
+                                PRE genomes/
+                                PRE seeds/
+     2025-04-08 16:39:17      62488 genomes.chunks.bin
+     2025-04-08 16:39:17   54209660 genomes.map.bin
+     2025-04-08 22:32:35        619 info.toml
+     2025-04-08 22:32:36     160032 masks.bin
+
+Download the index (it’s 5.24 TiB!!!, make sure you have enough disk
+space).
+
+    aws s3 cp s3://allthebacteria-lexicmap/202408/ atb.lmi --recursive --no-sign-request
+
+    # dirsize atb.lmi
+    atb.lmi: 5.24 TiB (5,758,875,365,595)
+      2.87 TiB      seeds
+      2.37 TiB      genomes
+     51.70 MiB      genomes.map.bin
+    156.28 KiB      masks.bin
+     61.02 KiB      genomes.chunks.bin
+         619 B      info.toml
+
+[Install](https://bioinf.shenwei.me/LexicMap/installation/) and
+[search](https://bioinf.shenwei.me/LexicMap/tutorials/search/) with
+LexicMap.
+
+## Building an index and searching locally {#building-an-index-and-searching-locally}
+
+**Make sure you have enough disk space, at least 8 TB, \>10 TB is
+preferred.**
+
+Tools:
+
+- [LexicMap](https://bioinf.shenwei.me/LexicMap/installation/)
+- <https://github.com/shenwei356/rush>, for running jobs in parallel
+
+Steps:
+
+1.  Downloading the list file of all [assemblies](https://osf.io/zxfmy/)
+    in the latest version (v0.2 plus incremental versions).
+
+        mkdir -p atb;
+        cd atb;
+
+        # Attention, the URL might change,
+        # please check in the browser: https://osf.io/zxfmy/files/osfstorage
+        wget https://osf.io/download/4yv85/ -O file_list.all.latest.tsv.gz
+
+    If you only need to add assemblies from an incremental version,
+    please manually download the file list
+    [here](https://osf.io/zxfmy/files/osfstorage).
+
+2.  Downloading assembly tarball files.
+
+        # Tarball file names and their URLs
+        zcat file_list.all.latest.tsv.gz | awk -F'\t' 'NR>1 {print $5"\t"$6}' | uniq > tar2url.tsv
+
+        # Download. If it’s interrupted, just rerun the same command.
+        cat tar2url.tsv | rush --eta -j 2 -c -C download.rush 'wget -O {1} {2}'
+
+3.  Decompressing all tarballs. The decompressed genomes are stored in
+    plain text, so we use `gzip` (can be replaced with faster `pigz`) to
+    compress them to save disk space.
+
+        # {^tar.xz} is for removing the suffix "tar.xz"
+        ls *.tar.xz | rush --eta -c -C decompress.rush 'tar -Jxf {}; gzip -f {^.tar.xz}/*.fa'
+
+        cd ..
+
+    After that, the assemblies directory would have multiple
+    subdirectories. When you give the directory to `lexicmap index -I`,
+    it can recursively scan (plain or gz/xz/zstd-compressed) genome
+    files. You can also give a file list with selected assemblies.
+
+        $ tree atb | more
+        atb
+        ├── atb.assembly.r0.2.batch.1
+        │   ├── SAMD00013333.fa.gz
+        │   ├── SAMD00049594.fa.gz
+        │   ├── SAMD00195911.fa.gz
+        │   ├── SAMD00195914.fa.gz
+
+4.  Prepare a file list of assemblies.
+
+    - Just use `find` or [fd](https://github.com/sharkdp/fd) (much
+      faster).
+
+          # find
+          find atb/ -name "*.fa.gz" > files.txt
+
+          # fd
+          fd .fa.gz$ atb/ > files.txt
+
+      What it looks like:
+
+          $ head -n 2 files.txt
+          atb/atb.assembly.r0.2.batch.1/SAMD00013333.fa.gz
+          atb/atb.assembly.r0.2.batch.1/SAMD00049594.fa.gz
+
+    - (Optional) Only keep assemblies of high-quality. Please [click
+      this link](https://osf.io/download/m26zn/) to download the
+      `hq_set.sample_list.txt.gz` file, or from this
+      [page](https://osf.io/h7wzy/files/osfstorage/).
+
+          find atb/ -name "*.fa.gz" | grep -w -f <(zcat hq_set.sample_list.txt.gz) > files.txt
+
+5.  Creating a LexicMap index
+    ([tutorials](https://bioinf.shenwei.me/LexicMap/tutorials/index/)).
+    It took 47h40m and 145GB RAM with 48 CPUs for 2.44 million ATB
+    genomes.
+
+        lexicmap index -S -X files.txt -O atb.lmi -b 25000 --log atb.lmi.log
+
+        # dirsize atb.lmi
+        atb.lmi: 5.24 TiB (5,758,875,365,595)
+          2.87 TiB      seeds
+          2.37 TiB      genomes
+         51.70 MiB      genomes.map.bin
+        156.28 KiB      masks.bin
+         61.02 KiB      genomes.chunks.bin
+             619 B      info.toml
+
+6.  (Optional) Prepare Taxonomy data to limit TaxId in
+    `lexicmap search` since LexicMap
+    v0.7.1.
+
+        # Download species_calls.tsv.gz file in the directory (Latest_2024-08) of this page:
+        # https://osf.io/h7wzy/files/osfstorage#
+        wget https://osf.io/download/7t9qd/ -O species_calls.tsv.gz
+
+        # Download gtdb-taxdump files of version r214 that was used in
+        # taxonomic classification of AllTheBacteria v2.0 and incremental 202408
+        # from here: https://github.com/shenwei356/gtdb-taxdump/releases/tag/v0.4.0
+        wget https://github.com/shenwei356/gtdb-taxdump/releases/download/v0.4.0/gtdb-taxdump.tar.gz
+
+        tar -zxvf gtdb-taxdump.tar.gz
+        mv gtdb-taxdump/R214 taxdump
+
+        # Prepare A file mapping assembly accession to TaxId
+        # using TaxonKit: https://github.com/shenwei356/taxonkit
+        cat species_calls.tsv.gz | sed 1d | cut -f 1,2 \
+            | taxonkit name2taxid --data-dir taxdump/ -i 2 \
+            | cut -f 1,3 \
+            > taxid.map
+
+7.  Searching with LexicMap
+    ([tutorial](https://bioinf.shenwei.me/LexicMap/tutorials/search/)).

--- a/content/docs/lexicmap.md
+++ b/content/docs/lexicmap.md
@@ -1,6 +1,6 @@
 ---
 title: Sequence alignment with LexicMap
-weight: 13
+weight: 140
 toc: true
 ---
 

--- a/content/docs/metadata_sqlite.md
+++ b/content/docs/metadata_sqlite.md
@@ -1,0 +1,423 @@
+---
+title: SQLite metadata
+weight: 3
+toc: true
+---
+
+This page describes the state of the metadata for all samples as of
+2025-05-06. It is collated into an SQLite database. There also an SQLite
+database available for the state of AllTheBacteria up to and including
+incremental release 2024-08.
+
+This is very detailed; if you just want simple flat files, then please
+see the [Metadata and QC](/docs/sample_metadata/) page.
+
+The 202505 SQLite database is in the file
+`atb.metadata.202505.sqlite.xz`, available from OSF at:
+<https://osf.io/h7wzy/files/my56u>.
+
+Download in a terminal with:
+
+    wget -O atb.metadata.202505.sqlite.xz https://osf.io/download/my56u/
+
+It has:
+
+- metadata from the ENA
+- the status of all samples (assembled, assembly failed, not processed
+  etc)
+- sylph results
+- assembly statistics (N50 etc)
+- checkm2 results
+
+The details here are important and quite complicated, and there are many
+different cases to consider within the metadata. We recommend you read
+this whole page carefully if you want to fully understand the how we
+processed the samples in release 0.2, incremental release 2024-08, and
+incremental release 202505.
+
+Note that the SQLite file `atb.metadata.202505.sqlite.xz` on OSF is
+compressed in xz format, and is approximately 2G. It will need to be
+decompressed to use it, with a size of around 27G.
+
+## Background up to release 2024-08
+
+AllTheBacteria is an extension of the 2021 "661k" project from Blackwell
+et al: we started with the set of samples/assemblies used in the 661k.
+AllTheBacteria adds to the 661k by processing all samples in the ENA
+that pass metadata checks and are not already in the 661k. The resulting
+new assemblies are added to the set of existing 661k assemblies.
+
+The original 661k project and AllTheBacteria both used data dumped from
+the ENA to identify samples and sequencing runs for assembly. As of
+August 2024, we have three sources of ENA metadata: the supplementary
+file from the 661k paper, and dumps of ENA metadata taken on 2024-06-25
+and 2024-08-01.
+
+For AllTheBacteria, assemblies were processed in batches. There was an
+initial batch in 2023, then two more batches 2024-06-25 and 2024-08-01.
+Each time, using ENA metadata. Note that we do not have the ENA dump
+from 2023, but do have a lookup of sample to run for each assembled
+sample. For each new batch, we simply asked: for each sample, have we
+processed it already, and if not then does it have exactly one
+sequencing run we can use? If the answer was yes, then it was processed.
+
+Unfortunately, it turns out that metadata can and does change. For
+example, runs or samples can be suppressed, a run could change which
+sample it links to, or FASTQ files (and therefore md5sum) can change.
+And at the same time, the last updated field can remain constant. This
+complicates things, especially as we discovered the changeable nature of
+the metadata after releasing the incremental release 2024-08.
+
+The SQLite database gathers all this information together, and includes
+a summary table of all known samples. This documents whether each sample
+was processed, which runs were used, and results of stringent metadata
+checks across all of our metadata sources. Essentially, we now require a
+sample to pass all our metadata checks, and remain consistent across all
+the sources of metadata. We have been intentionally paranoid, preferring
+to flag up anything unusual at the expense of potentially rejecting more
+samples than is necessary.
+
+This analysis does not redefine either release 0.2 or incremental
+release 2024-08. These assemblies are all still available from OSF and
+AWS. No assemblies have been added or removed. However, we now identify
+samples that were not previously flagged, because the new checks are
+more stringent. In particular, one reason for this is failing to
+accession an assembly in the ENA. The ENA rejects a submission if the
+sample's metadata fails various checks. This is out of our control,
+meaning that there are assemblies in release 0.2 and/or incremental
+release 2024-08 that are not in the ENA, and only available from OSF and
+AWS.
+
+## Background for release 2025-05
+
+Incremental release takes AllTheBacteria up to date as of the metadata
+in the ENA on 2025-05-06.
+
+Essentially the same process as above was used for incremental release
+2025-05. We started with the state of the project as of incremental
+release 2024-08, and processed new samples monthly. ENA metadata was
+retrieved on the dates 2024-09-13, 2024-10-07, 2024-11-01, 2024-12-17,
+2025-01-08, 2025-02-03, 2025-03-04, 2025-04-04, and 2025-05-06. New
+runs/samples that passed all the metadata checks were processed through
+the assembly pipeline.
+
+To be included in the incremental release 2025-05, a sample/run must be
+in 2025-05-06 (as well as the from the date it was first retrieved), and
+metadata must pass all the checks and be consistent across all sets of
+metadata. For example, a sample could have been processed in the
+2024-10-07 batch. To be included in incremental release 2025-05 it must
+also be in the 2025-05-06 ENA metadata, with the metadata consistent
+between 2024-10-07 and 2025-05-06. If that sample was not in 2025-05-06
+(samples get suppressed) or for example the md5 of the run fastq files
+changed, then it would not be included in release 2025-05.
+
+## Metadata checks
+
+For the 661k set, we can infer which run(s) were used for each sample
+for assembly using the 661k supplementary data, and the rules used to
+choose runs. The rules were: `instrument_platform` not `PACBIO_SMRT` or
+`OXFORD_NANOPORE`; `library_source` not `METAGENOMIC` or
+`TRANSCRIPTOMIC`; and `*_1.fastq.gz` and `*_2.fastq.gz` files must
+exist. Samples with more than one sequencing run were allowed.
+
+More stringent rules were used for new samples in AllTheBacteria. This
+means there are samples in the 661k set that would not be used if they
+were new and being considered for AllTheBacteria. For AllTheBacteria, we
+required `instrument_platform` = `ILLUMINA`, `library_strategy` = `WGS`,
+`library_source` = `GENOMIC`, `library_layout` = `PAIRED`, and
+`*_1.fastq.gz` and `*_2.fastq.gz` files must exist. There must also be
+exactly one sequencing run that passes for a given sample. We also know
+exactly which run was used for each sample that was assembled.
+
+## SQLite database
+
+### ENA metadata tables
+
+There are five ENA metadata tables in the database:
+
+- `ena_20240625`
+- `ena_20240801`
+- `ena_20250506`
+- `ena_202505_used`
+- `ena_661k`
+
+The `ena_20240625`, `ena_20240801`, `ena_20250506` tables are unedited
+dumps of all bacteria sequencing runs from the ENA. The query used was:
+
+    curl -Ss "https://www.ebi.ac.uk/ena/portal/api/search?result=read_run&fields=ALL&query=tax_tree(2)&format=tsv"
+
+The table `ena_202505_used` is a record of the metadata for each
+sample/run from release 2025-05 from when it was retrieved as part of
+the monthly processing, ie a record from one of the dates 2024-09-13,
+2024-10-07, 2024-11-01, 2024-12-17, 2025-01-08, 2025-02-03, 2025-03-04,
+2025-04-04, or 2025-05-06. The columns are the same as in the other
+unedited dumps from the ENA (`ena_20240625`, `ena_20240801`,
+`ena_20250506`), but with the column `obtained_date` added, which is the
+date when the record was retrieved from the ENA.
+
+The 661k supplementary files are here on Figshare:
+<https://doi.org/10.6084/m9.figshare.16437939.v1>. The 661k table
+`ena_661k` in the database is generated from the supplementary file
+`Json1_ENA_metadata.json.gz`. Note that we were unable to use the file
+`File9_all_metadata_ena_661K.txt` because it has one line per sample,
+and where a sample had more than one run it is not always possible to
+get some key information such as the platform of each run when there is
+a mix of platforms. The file `Json1_ENA_metadata.json.gz` is a subset of
+all ENA fields (but does contain all the ones we need here), so has
+fewer columns than the other two ENA tables.
+
+Column names in these tables are the same as those used in the dump of
+data from the ENA. In all three tables `run_accession` is the primary
+key.
+
+### Run table
+
+The SQLite database has a table `run` containing all 3,530,513 runs
+found in at least one of the ENA metadata tables. It is a summary of
+pass/fail of the metadata checks, and which of the ENA tables the run
+was found in.
+
+The columns are:
+
+- `run_accession`: ENA run accession. Primary key for the table.
+- `sample_accession`: ENA sample accession. Where the run matches more
+  than one sample, it is a comma-separated list of samples.
+- `in_661k`: `0` or `1` to show if this run is in the `ena_661k` table
+- `in_ena_20240625`: `0` or `1` to show if this run is in the
+  `ena_20240625` table
+- `in_ena_20240801`: `0` or `1` to show if this run is in the
+  `ena_20240801` table
+- `in_ena_20250506`: `0` or `1` to show if this run is in the
+  `ena_20250506` table
+- `ena_202505_batch`: for runs that are in `ena_202505_used`, the
+  batch/date of when the metadata was retrieved
+- `fastq_md5`: if known, the `fastq_md5` entry from ENA metadata. Some
+  FASTQ files have changed, in which case this says "multiple" instead
+  of a list of different md5 sums (we don't want to use these runs
+  anyway)
+- `meta_pass_atb`: `0` or `1` to show if this run passes AllTheBacteria
+  metadata checks (described above)
+- `meta_pass_661k`: `0` or `1` to show if this run passes 661k metadata
+  checks (described above)
+- `pass`: `0` or `1` to show overall if this run passes all checks. The
+  reasons for a fail are listed below.
+- `comments`: any useful comments related to why a run failed a check.
+
+A run will have `pass` = `0` if one (or more) of the following is true:
+
+- The run fails one or both of `meta_pass_atb`, `meta_pass_661k`
+- The run matches more than one sample
+- The sample that the run matches changed between ENA metadata tables
+- It is not in the 20250506 ENA metadata - ie it used to be available,
+  but now it is unavailable
+- One or more of the values of `fastq_md5`, `fastq_bytes`, `base_count`
+  has changed between ENA metadata tables. Changed values are common in
+  many of the fields, which we ignore, but these three are critical
+  because they mean that the FASTQ files have changed.
+
+### Assemblies/Samples table
+
+The sample/assemblies table is called `assembly` and contains the union
+all samples found in the table `runs` and all processed samples in
+AllTheBacteria releases. There were samples obtained in 2023 (and
+assembled and included in release 0.2) that do not appear in the ENA
+data dumps 20240625 or 20240801. Similarly, there are samples that are
+in older releases that do not appear in ENA dumps used for incremental
+release 2025-05.
+
+The columns of the table are:
+
+- `sample_accession`: the ENA sample accession. Primary key.
+- `run_accession`: the run accession(s) used when processing this sample
+  and making the assembly. This is NOT all run(s) associated with the
+  sample. Where there is more than one run, it is a comma-separated
+  list.
+- `assembly_accession`: this is the ENA assembly accession if the
+  assembly was successfully submitted to the ENA, otherwise it is `NA`.
+- `assembly_seqkit_sum`: the output of running `seqkit sum` on the
+  assembly.
+- `asm_pipe_filter`: a list of filters that this sample fails, or `PASS`
+  if it passed all filters (similar to how the VCF filter column works).
+  This is onlt for the assembly pipeline. See also the columns
+  `sylph_filter` and `hq_filter`. This column uses the latest filters,
+  not those used initially to find samples to process. This means a
+  sample could be in the 661k, release 0.2 or incremental releases but
+  not have `PASS` in this column.
+- `asm_fasta_on_osf`: `0` or `1` to indicate if an assembly FASTA file
+  of this sample is available on OSF (and also AWS). This corresponds
+  exactly to the assemblies in release 0.2 plus incremental releases
+  2024-08, 2025-05. See comments for the `filter` column - a sample
+  could fail the filter, but still have `1` in this column.
+- `dataset`: the dataset to which the sample belongs. Note: release 0.2
+  includes all of the 661k assemblies. However, in this table we
+  explicitly say which samples are in the 661k data set. Meaning that
+  "r0.2" in this field means the sample is in release 0.2 but is not in
+  the 661k set. Samples in the original 661k set have "661k" in this
+  column.
+- `scientific_name`: the ENA metadata scientific name. Some samples have
+  more than one run, and runs could have different entries, in which
+  case this is a semicolon-separated list. See also the
+  [Species Identification](/docs/species_id/) page.
+- `sylph_species_pre_202505`: the species call made from parsing sylph
+  output, in releases before 2025-05
+- `in_hq_pre_202505`: whether or not the sample was considered "high
+  quality" in releases before 2025-05.
+- `sylph_species`: this is a species call from running sylph on the
+  reads, using the method described in the
+  [Species Identification](/docs/species_id/) page.
+- `sylph_filter`: either PASS or a reason why the run(s) for this sample
+  failed getting a species. Fails could be: `MULTIPLE` where there is
+  more than one species call that passed the filters; `NO_SYLPH_RESULTS`
+  where sylph gave no output; `SYLPH_RESULTS_FAIL` where no sylph calls
+  passed the filters.
+- `hq_filter`: either PASS if the sample is considered high quality, or
+  a list of reasons it failed.
+- `osf_tarball_filename`: the filename of the `*.tar.xz` file on OSF
+  that contains the assembly FASTA file
+- `osf_tarball_url`: the URL of the `*.tar.xz` file on OSF
+- `aws_url`: the AWS URL of the assembly FASTA file
+- `comments`: any comments related to reasons for filter fails.
+
+These are the possible filters in the `asm_pip_filter` column due to
+metadata fails:
+
+- `NO_RUNS`: there are no runs that pass all checks, ie have `pass` =
+  `1` in the `run` table. It does not mean that there are literally zero
+  runs for the sample. It means there were no runs that we could
+  reliably use.
+- `RUN_REMOVED`: the run(s) that were used for the assembly are no
+  longer available.
+- `RMMS`: this stands for "Run Matches Multiple Samples". For each run
+  matching this sample, we then look up that run's samples. If there is
+  more than one matching sample in total across all runs, then this
+  filter is added. It means there is ambiguity (or a mistake), instead
+  of a one-to-one mapping of sample to/from run.
+- `META_FAIL`: the sample has one or more runs that failed one or more
+  AllTheBacteria metadata checks, but those runs were used in the 661k
+  dataset.
+- `RUN_CHANGE`: the run used for this assembly is now linked to a
+  different sample.
+
+Samples that passed the metadata filters can then fail during the
+assembly pipeline. The filters are:
+
+- `ASM_DLR`: downloading the reads failed.
+- `ASM_SYL`: sylph failed. This is actually because the downloaded FASTQ
+  files are truncated - despite having the correct md5 sum - and causes
+  sylph to crash. This is in older (before 2025-05) files, and has since
+  been replaced with `ASM_FQ_GZIP`.
+- `ASM_FQ_GZIP`: At least one of the downloaded run files has a
+  truncated FASTQ file, despite having the expected md5sum. FASTQ files
+  are valid gzip files.
+- `ASM_SHV`: shovill failed.
+- `ASM_LEN`: the assembly is too long or short.
+- `ASM_TIME`: the pipeline hit the time limit of 1000 minutes before
+  finishing.
+
+When an assembly is submitted to the ENA for accessioning, the ENA runs
+various metadata checks on the sample. It is possible for the assembly
+to then be rejected. If this happens then it gets the filter
+`ENA_ASM_SUBMIT_ERR`. We used the bulk submission tool from here:
+<https://github.com/enasequence/ena-bulk-webincli>. Samples were
+rejected for various reasons, which are added to the `comments` field of
+the `assembly` table. These were shortened in the table. The meaning of
+the most common are:
+
+- `error_organism_not_submittable_XYZ` - the error was of the form
+  `ERROR: Organism is not Submittable: XYZ`, where "XYZ" is the name of
+  a genus. This accounts for around half of the errors.
+- `error_serovar_only_occur_once` - the error was:
+  `ERROR: Qualifier "serovar" may occur only once for feature "source", not "2".`
+- `no_run_in_ENA` - the error was one of a few saying that the run was
+  unknown or cannot be referenced
+- `error_qualifier_collection_date_only_occur_once` - the error was:
+  `ERROR: Qualifier "collection_date" may occur only once for feature "source", not "2".`
+- `error_strain_must_exist_when_substrain_exists` - the error was:
+  `ERROR: The qualifier "strain" must exist when qualifier "sub_strain" exists within the same feature.`
+- `error_multiple_strain_isolate__qualifiers` - the error was:
+  `ERROR: Multiple Strain/Isolate qualifiers are not allowed in source feature.`
+- `error_env_sample_and_strain_cannot_exist_together` - the error was:
+  `ERROR: Qualifiers environmental_sample and strain cannot exist together.`
+- `error_serovar_only_exist_if_taxon_division_has_values_PRO` - the
+  error was:
+  `ERROR: Qualifier "serovar" can only exist if taxonomic division has one of the values "PRO".`
+- `error_variety_only_exist_if_taxon_division_PLN_FUN` - the error was:
+  `ERROR: Qualifier "variety" can only exist if taxonomic division has one of the values "PLN,FUN".`
+- `error_isolation_source_only_occur_once` - the error was:
+  `ERROR: Qualifier "isolation_source" may occur only once for feature "source", not "2".`
+- `error_cultivar_only_exist_if_taxon_division_PLN` - the error was:
+  `ERROR: Qualifier "cultivar" can only exist if taxonomic division has one of the values "PLN".`
+
+There is also the filter `NOT_PROCESSED`, which is for samples that are
+not in release 0.2 or incremental release 2024-08. There are some
+samples that do pass all the metadata checks, but were not processed.
+These will be processed in a future release of AllTheBacteria. The main
+reason is that we discovered a bug in the Python script that parses the
+ENA TSV file, causing it to silently skip over a few hundred records. If
+you are using Python's `csv.DictReader` to parse the file, then use the
+options `quotechar=None` and `quoting=csv.QUOTE_NONE` to avoid this bug.
+
+### Sylph table
+
+The table `sylph` has all sylph results from all runs of sylph that
+produced an output. Sequencing runs that had no sylph matches are not in
+this table. This table includes sequencing runs that have since been
+suppressed/removed from the ENA.
+
+The columns in this table are directly from the sylph output, except:
+
+- The `Sample_file` column is replaced with the INSDC accession column
+  `run_accession`
+- An extra column `Species` is added, which is a species call from the
+  `Genome_file` column, using GTDB species names.
+
+### Assembly statistics table
+
+The results of running `assembly-stats` (from
+<https://github.com/sanger-pathogens/assembly-stats>) on all assemblies
+are in the table `assembly_stats`.
+
+The columns in this table are taken directly from `assembly-stats`
+output, except the `filename` column is replaced with
+`sample_accession`, which is the primary key for the table.
+
+### Checkm2 table
+
+The table `checkm2` has results of running checkm2 on the assemblies.
+The columns in the output file are the original output from checkm2 but
+with the first `Name` column replaced with `sample_accession`, which is
+the primary key for the table. There is also an extra column
+`Additional_Notes` that contains the reason for any failed runs, in
+which case all fields except for `sample_accession` and
+`Additional_notes` are `null`.
+
+## Example SQLite queries
+
+Get all samples that have an assembly on OSF/AWS, ie this is release 0.2
+(which includes 661k) and incremental releases 2024-08, 2025-05:
+
+    SELECT * FROM assembly WHERE asm_fasta_on_osf=1;
+
+Get the sample and ENA assembly accessions of all samples in incremental
+release 2024-08 that have an ENA accession:
+
+    SELECT sample_accession,assembly_accession
+    FROM assembly
+    WHERE dataset="Incr_release.202408" AND assembly_accession !="NA";
+
+Get all samples with an assembly on OSF/AWS with N50 at least 1000000:
+
+    SELECT assembly.sample_accession, assembly.dataset, assembly_stats.total_length, assembly_stats.N50
+    FROM assembly JOIN assembly_stats ON assembly.sample_accession = assembly_stats.sample_accession
+    WHERE assembly_stats.N50 > 1000000 AND assembly.asm_fasta_on_osf=1;
+
+Get the assembly info and ENA 20240801 metadata for sample SAMN02391170:
+
+    SELECT * FROM assembly
+    JOIN ena_20240801 ON assembly.sample_accession = ena_20240801.sample_accession
+    WHERE assembly.sample_accession = "SAMN02391170";
+
+In a terminal (not SQLite prompt), dump the assembly table to a
+tab-delimited file:
+
+    sqlite3 -header atb.metadata.202408.sqlite -cmd '.mode tabs' 'select * from assembly' > assembly.tsv

--- a/content/docs/metadata_sqlite.md
+++ b/content/docs/metadata_sqlite.md
@@ -1,6 +1,6 @@
 ---
 title: SQLite metadata
-weight: 3
+weight: 40
 toc: true
 ---
 

--- a/content/docs/osf_downloads.md
+++ b/content/docs/osf_downloads.md
@@ -1,0 +1,85 @@
+---
+title: Batch downloading from OSF
+weight: 15
+toc: true
+---
+
+The data are all hosted on OSF: <https://osf.io/xv7q9/>
+
+If you only want a few files, then browsing the website an manually
+downloading works fine. This page describes how to download files in
+bulk. It is not immediately obvious how to do so, because you need to
+get the URLs of the files you want to download.
+
+## All latest files
+
+We provide a tab-delimited file of all the files that are on OSF for the
+whole AllTheBacteria project: [all_atb_files.tsv](https://osf.io/r6gcp).
+This is subject to change, and is updated when files change on OSF.
+
+The columns are:
+
+- `project`: the name of the project/component, plus its parents, with
+  the names separated by `/`. For example the Metadata component sits
+  directly under the main AllTheBacteria project, and is called
+  `AlTheBacteria/Metadata`.
+- `project_id`: the project identifier. This is useful if you want to
+  make your own file list (see below)
+- `filename`: the name of the file
+- `url`: the URL of the file
+- `md5`: the MD5 sum of the file
+- `size(MB)`: size of the file in MB
+
+Using this file, it is then relatively easy to batch download. For
+example, the ENA metadata file for release 0.2 has this information:
+
+    project     AllTheBacteria/Metadata
+    project_id  h7wzy
+    filename    0.2/ena_metadata.tsv.gz
+    url         https://osf.io/download/6661ba5c65e1de509c893bb6/
+    md5         47d03a4892ae6ec5f337c9854e67b7af
+
+You could use `wget` to download:
+
+    wget -O ena_metadata.tsv.gz https://osf.io/download/6661ba5c65e1de509c893bb6/
+
+and then check the MD5 sum is correct.
+
+## Making file lists
+
+Ignore this section if you just want to use the file list provided by
+us. Otherwise, keep reading.
+
+A file list can be made with this script:
+<https://github.com/martinghunt/bioinf-scripts/blob/master/python/osf_get_files_for_project.py>
+
+It gathers all the files for one component on OSF, taking the identifier
+you see in the component's URL as input. It recursively finds all
+descendants of component that you give it, in other words, all of the
+sub-projects/components underneath the main component.
+
+The default output format is TSV, which is what we use to make the lists
+that go on OSF, with the columns as described above. You can instead get
+JSON output, which returns all the metadata for each file, with
+`--format json`. This contains a large amount of data!
+
+### Get all the files
+
+The project identifier of AllTheBacteria is `xv7q9`. The file
+`all_atb_files.tsv` is made with:
+
+    osf_get_files_for_project.py xv7q9 > all_atb_files.tsv
+
+### Files for one project
+
+You need to find the project identifier to input to
+`osf_get_files_for_project.py`. This will be in the file
+`all_atb_files.tsv` (the `project_id` column), or at the end of the URL
+in your browser. For example, the URL of the metadata component is
+<https://osf.io/h7wzy/> and you need to input `h7wzy` to the script. The
+usage is:
+
+    osf_get_files_for_project.py h7wzy > file_list.tsv
+
+(replace `h7wzy` with the appropriate string depending on the component
+you want).

--- a/content/docs/osf_downloads.md
+++ b/content/docs/osf_downloads.md
@@ -1,6 +1,6 @@
 ---
 title: Batch downloading from OSF
-weight: 15
+weight: 160
 toc: true
 ---
 

--- a/content/docs/osf_links.md
+++ b/content/docs/osf_links.md
@@ -1,6 +1,6 @@
 ---
 title: OSF links
-weight: 3
+weight: 30
 toc: false
 ---
 

--- a/content/docs/osf_links.md
+++ b/content/docs/osf_links.md
@@ -1,0 +1,25 @@
+---
+title: OSF links
+weight: 3
+toc: false
+---
+
+This page pairs each documentation section with the corresponding OSF
+project or component. In each row, the first link goes to the
+documentation page on this website, and the second link goes to the
+matching OSF destination.
+
+| Docs page | OSF link |
+|---|---|
+| [Overview](/docs/overview/) | [AllTheBacteria project on OSF](https://osf.io/xv7q9/) |
+| [Metadata and QC](/docs/sample_metadata/) | [Metadata component](https://osf.io/h7wzy/) |
+| [SQLite metadata](/docs/metadata_sqlite/) | [Metadata component](https://osf.io/h7wzy/) |
+| [Assemblies](/docs/assemblies/) | [Assembly component](https://osf.io/zxfmy/) |
+| [Species identification](/docs/species_id/) | [Metadata component](https://osf.io/h7wzy/) |
+| [Annotation](/docs/annotation/) | [Bakta component](https://osf.io/zt57s/) |
+| [Antimicrobial resistance](/docs/amr/) | [AMRFinderPlus component](https://osf.io/7nwrx/) |
+| [Defense systems](/docs/defense/) | [DefenseFinder component](https://osf.io/hpgac/) |
+| [Biosynthetic gene clusters](/docs/bgcs/) | [GECCO component](https://osf.io/cufb2/) |
+| [Hypothetical protein structures](/docs/hypothetical_protein_structures/) | [Structure databases component](https://osf.io/x693m/) |
+| [Species specific typing](/docs/typing/) | [Acinetobacter baumannii serotyping](https://osf.io/vjma7/), [Bacillus cereus group](https://osf.io/8ua49/), [Clostridium perfringens toxinotyping](https://osf.io/djhga/), [Listeria monocytogenes LisSero typing](https://osf.io/9cbqg/), [Shigella serotyping and species ID](https://osf.io/6a8mv/), [Vibrio parahaemolyticus serotyping](https://osf.io/xc26j/) |
+| [Archaea](/docs/archaea/) | [Archaea component](https://osf.io/nehtp/) |

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1,0 +1,139 @@
+---
+title: Overview
+weight: 1
+toc: true
+---
+
+## Current status
+
+Date updated: 2026-02-26.
+
+### Bacteria
+
+The latest release is incremental release 2025-05
+
+| Release             | Assemblies | Grand total |
+|---------------------|------------|-------------|
+| r0.2 <sup>1</sup>   | 1,932,812  | 1,932,812   |
+| Incremental 2024-08 | 507,565    | 2,440,377   |
+| Incremental 2025-05 | 322,920    | 2,763,297   |
+
+\[1\]: 661,384 in the original 661k Blackwell dataset, plus 1,271,428
+new assemblies
+
+Post-assembly analysis status
+
+| Analysis                                  | r0.2 | 2024-08 | 2025-05 |
+|-------------------------------------------|------|---------|---------|
+| assembly-stats                            | ✓    | ✓       | ✓       |
+| checkm2                                   | ✓    | ✓       | ✓       |
+| [Lexicmap index](/docs/lexicmap/) <sup>1</sup> | ✓    | ✓       | ✗       |
+| sketchlib index <sup>1</sup>              | ✓    | ✓       | ✗       |
+| [Annotation](/docs/annotation/)                | ✓    | ✓       | ✗       |
+| [Antimicrobial resistance](/docs/amr/)         | ✓    | ✓       | ✗       |
+| [Species-specific typing](/docs/typing/)       | ✓    | ✓       | ✗       |
+| [Biosynthetic gene clusters](/docs/bgcs/)      | ✓    | ✓       | ✗       |
+| [Defense systems](/docs/defense/)              | ✓    | ✓       | ✗       |
+
+\[1\]: The indexes are for r0.2 plus 2024-08 combined, not two separate
+indexes.
+
+### Archaea
+
+The only release is 2024-07, and has 815 assemblies.
+
+## Where are the docs/data/methods?
+
+There are three places to go, depending on what you want:
+
+1.  Documentation: how to download and use the data/analysis files is
+    described in this documentation you are currently reading
+2.  Files: the data are all hosted on OSF: <https://osf.io/xv7q9/>,
+    which includes assembly and analysis files. For bulk downloads,
+    please read [Bulk Downloads](/docs/osf_downloads/).
+3.  [Assemblies](/docs/assemblies/) are available from OSF, AWS, and the ENA.
+4.  Methods/code: in-depth methods details and files for reproducibility
+    are stored in this github repository:
+    <https://github.com/AllTheBacteria/AllTheBacteria>. If you are just
+    using the data, you shouldn't need to look there.
+
+If you only want to use the data without caring about the methods then
+we suggest you read this documentation, which has the relevant links to
+OSF, as opposed to going directly to OSF.
+
+## A brief history of AllTheBacteria
+
+The bacterial sequence data publicly available at the global DNA
+archives is a vast source of information on the evolution of bacteria
+and their mobile elements. However, most of it is either unassembled or
+inconsistently assembled and quality-controlled. This makes it
+unsuitable for large-scale analyses, and inaccessible for most
+researchers to use. In 2021 Blackwell et al therefore released a
+uniformly assembled set of 661,405 genomes, consisting of all publicly
+available whole genome sequenced bacterial isolate data as of November
+2018, along with various search indexes
+(<https://doi.org/10.1371/journal.pbio.3001421>). AllTheBacteria extends
+that project, covering all data up to at least 2024, and is ongoing. We
+also expand the scope, as we begin a global collaborative project to
+generate annotations for different species as desired by different
+research communities.
+
+## Release Notes
+
+The first batch of data is available as release 0.2. From then onwards
+we make "incremental" releases, which contain new samples that are not
+included in older releases. This means that if you want the complete
+results for a particular analysis, you will need release 0.2 results
+plus all later incremental releases. When it makes sense to do so, we
+will make aggregated files of all the releases (ie 0.2 plus all
+incremental releases), so that you do not need to combine results
+yourself.
+
+### Releases 0.1 and 0.2
+
+In March 2024 we released version 0.1 of AllTheBacteria, which added
+1,271,428 new assemblies to the 661k dataset, taking the total to
+1,932,812 assemblies. It included all data up to May 2023. This is
+described in the bioRxiv preprint:
+<https://doi.org/10.1101/2024.03.08.584059>. The files were put on the
+EBI ftp site (<https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/>).
+
+We found 11,887 assemblies containing some contigs had matched the human
+genome. We removed these contigs, calling the resulting assemblies
+release 0.2. The original 0.1 release was deleted from the EBI ftp site,
+so that now only release 0.2 is available. Releases 0.1 and 0.2 contain
+the same samples, the only difference is 11,887 assemblies had one or
+more contigs removed.
+
+### Species names and migration from EBI ftp to OSF
+
+The assembly files are compressed using miniphy, which (approximately)
+batches files by species names. These species names are used in the
+output files. However, species calling will never be perfect, and so we
+wanted to remove species names from the assembly files.
+
+We decided to host the data at OSF from release 0.2 onwards. All files
+on the EBI ftp site are left as an archive. Those files do have species
+names in them. The files were renamed before uploading to OSF, as
+described in detail in the [migration to OSF page](/docs/ebi2osf/). The
+assemblies are identical in release 0.2 on from EBI and OSF, but the
+filenames are different.
+
+### Incremental Release 2024-08
+
+After release 0.2, we processed all new data up to August 2024, and
+released these new 507,566 assemblies with the name "incremental release
+2024-08". It is called "incremental" because it only contains the new
+assemblies.
+
+### Incremental Release 2025-05
+
+**Breaking change:** [species calls](/docs/species_id/) from sylph results
+were made more stringent compared to previous releases. This means there
+are samples that had a species call pre-2025-05, but now fail the new
+checks and do not have a species call.
+
+New samples/runs were processed after incremental release 2024-08,
+making incremental release 2025-05. This means that the complete
+AllTheBacteria dataset is release 0.2 plus incremental releases 2024-08
+and 2025-05.

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-weight: 1
+weight: 10
 toc: true
 ---
 

--- a/content/docs/release_history.md
+++ b/content/docs/release_history.md
@@ -1,0 +1,227 @@
+---
+title: Release history
+weight: 17
+toc: true
+---
+
+## Release Version 0.1
+
+WE HAVE REMOVED RELEASE 0.1 assemblies and indexes, as it contained
+human genome contamination; please see release 0.2 instead, which
+documents precisely which contigs were removed. Release 0.1 metadata is
+still available.
+
+## Release Version 0.2
+
+### Summary
+
+This the second release from the AllTheBacteria project, which seeks to
+make available a set of uniformly assembled and QC-ed genomes consisting
+of all single-isolate WGS illumina samples from the ENA/SRA as of a
+fixed date (in this case June 16th 2023). In future releases, through
+engagement with various research communities, these assemblies will be
+accompanied by gene annotation, pangenomes, feature annotation (eg AMR
+genes, MLST, serotypes) and mobile element detection. Finally, we will
+also release multiple different types of search index. Release 0.2
+provides the assembly, taxonomic information, basic assembly quality
+information, and 2 types of search index. It is an updated of version
+0.1 that has human contamination removed from assemblies.
+
+Please raise any issues here:
+<https://github.com/iqbal-lab-org/AllTheBacteria>
+
+Citation: <https://doi.org/10.1101/2024.03.08.584059>
+
+### Changes from version 0.1 to version 0.2
+
+Human decontamination:
+
+- 11,887 assemblies had contigs removed because they matched the human
+  genome.
+- Added `metadata/contam_contigs.json.gz`, which contains the samples
+  and contig ids that were removed.
+- No contigs were renamed. eg if contig 3 was removed from an assembly
+  that had contigs 1-5, then the contigs in the new assembly are called
+  1,2,4,5
+- Added `metadata/nucmer_human.gz`, which has the raw nucmer output from
+  mapping all assemblies to the human genome + HLA sequences
+
+These were rerun on the assemblies that had human contamination contigs
+removed:
+
+- assembly-stats, so the file `metadata/assembly-stats.tsv.gz` is
+  updated
+- checkm2, so the file `metadata/checkm2.tsv.gz` also updated
+
+The high quality dataset has also changed slightly, because of the
+changed assemblies:
+
+- the script to generate a "high quality" dataset has been updated. It
+  is now called `metadata/make_hq_sample_list.py`, and has all cutoff
+  exposed to the user, so it can be rerun with different parameters
+
+Species calls:
+
+- Version 0.1 had quick/hacky (not always correct) species calls made
+  solely for compressing the assemblies (in
+  `metadata/ample2species2file.tsv.gz`). It also had more accurate
+  species calls (in `metadata/hq_dataset.species_calls.tsv.gz`) from
+  more careful parsing of sylph results - these were used for the "high
+  quality" dataset analysis. This was confusing. Version 0.2 has a
+  single set of species calls.
+
+Indexing:
+
+- Added index files for searching with phylign.
+
+Misc:
+
+- Added file of md5sums `md5sum.txt` for all files in the release
+  (except for the READMEs).
+
+### Overview
+
+This release 0.2 includes the same 1,932,812 samples as in release 0.1.
+
+More than 1,932,812 samples were originally processed, however the
+release is for the samples that successfully resulted in an assembly
+with total length between 100kbp and 15Mbp. This means that some of the
+metadata files include more samples than the 1,932,812 (see details for
+each file below).
+
+661,384 of the 1,932,812 are from the "661k" bacteria assemblies dataset
+from Blackwell 2021 (<https://doi.org/10.1371/journal.pbio.3001421>).
+The exact original total of the 661k set was 661,405. 21 of these have
+total length greater than 15Mbp, leaving 661,384 assemblies included in
+this release of 1,932,812 samples.
+
+### Metadata
+
+The metadata files are in the directory `metadata/`.
+
+#### Sample accessions
+
+The 1,932,812 sample accessions are listed in the file
+`sample_list.txt.gz`.
+
+#### Species calls and high quality data set
+
+The species calls and high quality dataset are generated with the script
+`make_hq_sample_list.py`. The high quality dataset has 1,858,610
+samples.
+
+This script is updated since version 0.1 to expose all parameters to the
+user, so it can be rerun with different cutoffs. The defaults were used
+to define the high quality dataset here, which meant a sample must pass
+all of these requirements to be included as high quality:
+
+- Have a sylph call with at least 99 percent minimum abundance. If a
+  sample has more than one call (eg where it has more than one run),
+  then require all species calls to be the same
+- Minimum checkm2 completeness of 90%
+- Maximum checkm2 contamination of 5%
+- Total assembly length between 100kbp and 15Mbp
+- Maximum number of contigs 2,000
+- Minimum N50 2,000
+
+The species calls are in `species_calls.tsv.gz`, plus a column `HQ` with
+`T` (true) or `F` (false) showing if each sample was in the high quality
+dataset. The high quality sample IDs are also listed in the file
+`hq_set.sample_list.txt.gz`. The 74,202 rejected samples are listed in
+the file `hq_set.removed_samples.tsv.gz`, along with the reason(s) why.
+
+#### Assembly statistics
+
+Basic assembly statistics for each assembly are in
+`assembly-stats.tsv.gz`. These were made using `assembly-stats`
+(<https://github.com/sanger-pathogens/assembly-stats>) git commit
+7bdb58b.
+
+These results are a superset of the 1,932,812 samples. To restrict to
+the release 0.2 samples, filter on the column `in_v0.2 == "Y"`. There is
+also the column `in_661k` to show if each sample is in the 661k dataset.
+
+#### Checkm2
+
+Checkm2 (<https://doi.org/10.1038/s41592-023-01940-w>) version 1.0.1 was
+run on each assembly. The results are in the file `checkm2.tsv.gz`.
+Checkm2 was only run on the 1,932,812 samples. The columns in the output
+file are the original output from checkm2 but with the first "Name"
+column replaced with "sample", and then the values are the INSDC sample
+accession IDs.
+
+275 samples stopped mid-run, with the error message "ERROR: No DIAMOND
+annotation was generated. Exiting". These have "No DIAMOND annotation
+was generated" in the `Additional_Notes` column, and all other fields
+are "NA".
+
+#### Sylph
+
+Sylph (<https://doi.org/10.1101/2023.11.20.567879>) version 0.5.1 was
+run on the sequencing reads, using the pre-built GTDB r214 database
+(<https://storage.googleapis.com/sylph-stuff/v0.3-c200-gtdb-r214.syldb>).
+
+Sylph was run on a superset of the reads from the 1,932,812 samples, and
+the results are in `sylph.tsv.gz`.
+
+The contents of `sylph.tsv.gz` is the original sylph output, except for
+these differences:
+
+- Extra columns `in_v0.1`, `in_661k`, to show which dataset(s) each
+  sample belongs to.
+- The `Sample_file` column was replaced with the INSDC accession columns
+  `sample` and `Run`.
+- An extra column `Species` was added, which is a species call from the
+  `Genome_file` column.
+
+Some reads resulted in no sylph output, presumably because there were no
+matches. These 3252 samples are listed in the file
+`sylph.no_matches.txt.gz` and are not present in `sylph.tsv.gz`.
+
+#### Human contamination
+
+All assemblies were mapped to the human genome CHM13v2:
+(<https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/009/914/755/GCA_009914755.4_T2T-CHM13v2.0/GCA_009914755.4_T2T-CHM13v2.0_genomic.fna.gz>),
+plus HLA sequences (`IMGTHLA-3.55.0-alpha/hla_gen.fasta` from
+<https://github.com/ANHIG/IMGTHLA/archive/refs/tags/v3.55.0-alpha.zip>).
+
+We used `nucmer` (from mummer version 4.0.0rc1) with the defaults,
+`delta-filter -i 90 -l 100 -m`, and then `show-coords -dTlro`. The full
+results are in `nucmer_human.gz`.
+
+A contig was counted as human contamination and removed from an assembly
+if it had a match that was at least 99% identity and 90% of its total
+length. The removed samples/contigs are listed in
+`metadata/contam_contigs.json.gz`.
+
+### Sequence searching and ANI with sketchlib
+
+Please see the sketchlib section of the README on this ftp site:
+<https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/indexes/README.md>
+
+#### Sequence searching with Phylign
+
+Phylign (Břinda *et al*, 2023) allows efficient searching and full
+alignment of query sequences to huge datasets of bacterial assemblies
+that have been phylogenetically compressed using MiniPhy
+(<https://github.com/karel-brinda/MiniPhy>). We have recently adapted
+Phylign to allow users to align query sequences to AllTheBacteria v0.2
+or subsets of this dataset. Detailed information, including how to run
+Phylign on computing clusters, can be found in the README on our GitHub
+page (<https://github.com/AllTheBacteria/Phylign/blob/main/README.md>),
+and in README in the relevant directory on this ftp site
+(<https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/indexes/>)
+
+## Incremental release 2024-08
+
+This is an incremental release, adding 507,565 new assemblies.
+Sequencing metadata from the ENA was downloaded on 2024-08-01, and all
+eligible samples (ie paired Illumina, WGS etc) that were not already in
+release 0.2 were processed.
+
+## Incremental Release 2025-05
+
+This is an incremental release, adding 322,920 new assemblies.
+Sequencing metadata from the ENA was downloaded on 2025-05-05, and all
+eligible samples (ie paired Illumina, WGS etc) that were not already in
+previous releases were processed.

--- a/content/docs/release_history.md
+++ b/content/docs/release_history.md
@@ -1,6 +1,6 @@
 ---
 title: Release history
-weight: 17
+weight: 180
 toc: true
 ---
 

--- a/content/docs/sample_metadata.md
+++ b/content/docs/sample_metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata and QC
-weight: 2
+weight: 20
 toc: true
 ---
 

--- a/content/docs/sample_metadata.md
+++ b/content/docs/sample_metadata.md
@@ -1,0 +1,159 @@
+---
+title: Metadata and QC
+weight: 2
+toc: true
+---
+
+Metadata files are all stored on OSF in the AllTheBacteria [Metadata
+component](https://osf.io/h7wzy/).
+
+These files all relate to INSDC metadata, tracking which samples have
+been processed, and then results of running the assembly (and related
+tools) pipeline. They include:
+
+- ENA metadata (this is a snapshot at the time AllTheBacteria was
+  updated to add more samples)
+- Sample status at a high level: included in AllTheBacteria, or rejected
+  for some reason when running the assembly pipeline
+- Sylph results on the reads, and species calls made from the Sylph
+  results
+- Assembly statistics and checkm2 output
+- Nucmer contig matches of aligning to the human genome
+- "High quality" samples (defined below)
+
+## Metadata availability
+
+The metadata are available in two forms:
+
+1.  Flat files. These are described below. This is how all of the data
+    was released when we first uploaded everything to OSF in 2024.
+2.  In an [SQLite database](/docs/metadata_sqlite/), available for releases
+    2024-08 and 2025-05. It gathers together all of the ENA metadata,
+    assembly metadata, plus slpyh, checkm2 and assembly stats output.
+    The 2024-08 database contains more stringent checks on the metadata,
+    and so more samples are flagged as possibly unreliable than in the
+    flat files. From 2025-05 onwards, the database has the same
+    information as the flat files.
+
+This page describes the flat files. It is simpler than the database. The
+details of the metadata and the SQLite database are complicated, and are
+described in a separate page: [SQLite metadata](/docs/metadata_sqlite/)
+
+## Metadata files
+
+The latest complete set of data is release 0.2 plus incremental releases
+2024-08 and 2025-05. The latest metadata files for this set are in the
+`Aggregated/Latest_2025-05/` folder of the [Metadata
+component](https://osf.io/h7wzy/).
+
+### Status file
+
+The latest status of all processed samples is in the file
+[status.202505.tsv.gz](https://osf.io/h7wzy/files/6hw7t). It tracks the
+result of trying to download the reads, run sylph, assemble, and then
+human decontamination. The columns are:
+
+- `Sample`: the sample accession (SAM...)
+- `Status`: status of the sample. This is either "PASS", meaning that
+  the pipeline finished successfully and we have an assembly, or
+  "FAIL:..." if it failed and for what reason
+- `Dataset`: the dataset the sample belongs to
+- `HQ_filter`: "PASS" means this sample is in the "high quality" dataset
+- `Assembly_on_OSF`: `1` or `0` to indicate if the assembly is available
+  from OSF (and AWS). The complete set of AllTheBacteria assemblies is
+  the samples with `1` in this column.
+
+Note, the older status file for 2024-08 did not have the `HQ_filter`,
+`Assemby_on_OSF` columns, and had an extra column `Comments`.
+
+### Sample lists
+
+The file `sample_list.txt.gz` lists all samples that have an assembly.
+For aggregated data, it is the samples that have "PASS" in the "Status"
+column of the status file (described above).
+
+All of the samples in `sample_list.txt.gz` will be in the files
+described later (sylph, checkm2 etc). Those files will contain more
+samples because not every sample results in an assembly. For example,
+the reads for a given sample could be downloaded and sylph run
+successfully, and then the assembly fails. That sample would have sylph
+results, but no assembly, and so does not appear in
+`sample_list.txt.gz`.
+
+### ENA metadata
+
+When processing new samples, the first thing we do is download all
+metadata from the ENA for all bacteria. The results are in
+`ena_metadata.YYYYMMDD.tsv.gz` (where YYYYMMDD is the download date from
+the ENA) providing a snapshot at the time of download. These files are
+only included with each individual release. We do not make an aggregated
+file across releases, since it does not really make sense to do so.
+
+### Sylph
+
+After downloading the reads, sylph is run on them to get species
+abundances. The results are in the file `sylph.tsv.gz`, which is the
+original sylph output, except for these differences:
+
+- The `Sample_file` column is replaced with the INSDC accession columns
+  `Sample` and `Run`.
+- An extra column `Species` is added, which is a species call from the
+  `Genome_file` column, using GTDB species names.
+
+Some samples have no matches and there is no output - these samples are
+listed in the file `sylph.no_matches.tsv.gz`.
+
+We also try to make a species call from the sylph output, which can be
+found in `species_calls.tsv.gz`. The method used to make these calls has
+changed over time. Please see [species calls](/docs/species_id/) for more
+information.
+
+- r0.2 and incremental release 2024-08 used a naive method of requiring
+  a sylph match with more than 99% abundance
+- Incremental release 2025-05 used a more stringent method. The
+  aggregated file `species_calls.tsv.gz` for everything up to and
+  including release 2025-05 has the old calls in the column
+  `sylph_species_pre_202505` and the old "high quality" call in
+  `in_hq_pre_202505`. The updated species and high quality calls are in
+  the columns `sylph_species`, `HQ`.
+
+### Decontamination
+
+After assembly, we use nucmer to align the contigs to the human genome
+(plus HLA sequences). Matching contigs are removed from the assembly.
+The complete nucmer output is given in `human_nucmer.gz`. We do not
+provide an aggregated nucmer file of the latest data because it is
+relatively large.
+
+### Assembly statistics
+
+The results of running `assembly-stats` (from
+<https://github.com/sanger-pathogens/assembly-stats>) are provided in
+`assembly-stats.tsv.gz`.
+
+### Checkm2
+
+The results of running `checkm2` are provided in `checkm2.tsv.gz`. The
+columns in the output file are the original output from checkm2 but with
+the first "Name" column replaced with "Sample", and then the values are
+the INSDC sample accession IDs.
+
+### High quality dataset
+
+We define a high quality dataset for each release. For releases up to
+and including 2024-08, the requirements were:
+
+- Have a sylph call with at least 99 percent minimum abundance. If a
+  sample has more than one call (eg where it has more than one run),
+  then require all species calls to be the same
+- Minimum checkm2 completeness of 90%
+- Maximum checkm2 contamination of 5%
+- Total assembly length between 100kbp and 15Mbp
+- Maximum number of contigs 2,000
+- Minimum N50 2,000
+
+From 2025-05 onwards, the sylph parsing was made stricter, as described
+[here](/docs/species_id/). All other rules remained the same.
+
+The high quality samples are listed in `hq_set.samples_list.txt.gz`. The
+rejected samples are listed in `hq_set.removed_samples.tsv.gz`.

--- a/content/docs/species_id.md
+++ b/content/docs/species_id.md
@@ -1,0 +1,65 @@
+---
+title: Species identification
+weight: 5
+toc: true
+---
+
+Currently the species identification consists of the information in the
+ENA metadata, and from running sylph on the raw reads.
+
+**Important:** the method used to call species from sylph results was
+made more stringent in release 2025-05. Details are below. If you want a
+consistent set of species calls for everything up to and including
+2025-05, use the 2025-05 aggregated files. For reproducibility, the
+older (r0.2 and 2024-08) files were not changed and contain the old
+method species calls.
+
+## ENA species
+
+This is simply the value of the `scientific_name` in the ENA metadata,
+which is from the original submitter. It uses the NCBI taxonomy.
+
+## Sylph species
+
+This uses the GTDB taxonomy, which is inconsistent with the ENA/NCBI
+taxonomy.
+
+Sylph calls were filtered for quality using the following information:
+
+- `c` = the effective coverage `Eff_cof` column from Sylph
+- `k` = kmer length used by Sylph, which for AllTheBacteria was the
+  default 31
+- `g` = reference genome size, which was obtained from GTDB metadata. We
+  used column `genome_size` from
+  `https://data.ace.uq.edu.au/public/gtdb/data/releases/release214/214.0/bac120_metadata_r214.tar.gz`
+  and
+  `https://data.ace.uq.edu.au/public/gtdb/data/releases/release214/214.1/ar53_metadata_r214.tsv.gz`
+- `r`: read length, which was calculated by dividing the ENA
+  `base_count` by (2 \* `read_count`). Note that `base_count` is the
+  total of bases across both paired FASTQ files, and `read_count` is the
+  number of reads in one of the FASTQ files.
+
+To pass, the Sylph call must have:
+
+1.  `Sequence_abundance` at least 99.
+2.  `c * g * (r / (r - k + 1)) >= 0.5 * base_count`, which roughly means
+    that at least half of the reads match this genome. Although this may
+    sound like a low threshold, sequencing errors have a significant
+    detrimental affect on the calculation.
+
+Further, for a sample (not just a run) to pass, there can be only one
+species call that passes. A sample with more than one run could have two
+different species called, in which case it is failed. If all its passing
+run calls have the same species, then the sample passes.
+
+### 2025-05 vs pre-2025-05 calls
+
+**Important:** only condition 1 above was used to make species calls for
+releases r0.2 and 2024-08. This means files from 2024-08 and earlier
+have the calls using only condition 1. The stricter condition 2 was
+added from 2025-05 onwards. Files from 2025-05 onwards use the stricter
+condition 1 plus 2. Old files were not changed. This means that to get a
+consistent set of species calls, use the 2025-05 aggregated files (or
+the 2025-05 database). There are samples in r0.2/2024-08 that passed
+condition 1 but not condition 2, meaning that they had a species in
+r0.2/2024-08 but in 2025-05 are labelled as "unknown".

--- a/content/docs/species_id.md
+++ b/content/docs/species_id.md
@@ -1,6 +1,6 @@
 ---
 title: Species identification
-weight: 5
+weight: 60
 toc: true
 ---
 

--- a/content/docs/typing.md
+++ b/content/docs/typing.md
@@ -7,7 +7,7 @@ toc: true
 ## Summary
 
 All [sylph](https://github.com/bluenote-1577/sylph)-identified genomes
-from [AllTheBacteria](https://allthebacteria.readthedocs.io/en/latest/)
+from [AllTheBacteria](/docs/)
 `0.2` and `incremental release 2024-08` were typed using various tools
 
 *Bacillus cereus* group spp.

--- a/content/docs/typing.md
+++ b/content/docs/typing.md
@@ -1,6 +1,6 @@
 ---
 title: Species specific typing
-weight: 11
+weight: 120
 toc: true
 ---
 

--- a/content/docs/typing.md
+++ b/content/docs/typing.md
@@ -1,0 +1,85 @@
+---
+title: Species specific typing
+weight: 11
+toc: true
+---
+
+## Summary
+
+All [sylph](https://github.com/bluenote-1577/sylph)-identified genomes
+from [AllTheBacteria](https://allthebacteria.readthedocs.io/en/latest/)
+`0.2` and `incremental release 2024-08` were typed using various tools
+
+*Bacillus cereus* group spp.
+
+- [BTyper3](https://github.com/lmc297/BTyper3) v3.4.0 (Standardized
+  taxonomic classification and sequence typing, detection of virulence
+  and Bt toxin-encoding genes)
+- Result files are available on OSF in the [Bacillus_cereus_group
+  component](https://osf.io/8ua49/).
+
+*Bordetella pertussis*
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- [BPagST](https://pubmed.ncbi.nlm.nih.gov/35778384/) schema downloaded
+  [2024-06-10](https://bigsdb.pasteur.fr)
+
+*Corynebacterium diphtherieae*
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- Toxin
+
+*Haemophilus* spp.
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- [hicap](https://pubmed.ncbi.nlm.nih.gov/30944197/) v1.0.4 (capsule)
+
+*Klebsiella* spp.
+
+- [Kleborate](https://pubmed.ncbi.nlm.nih.gov/34234121/) v2.3.2 (MLST,
+  virulence, capsule, antimicrobial resistance)
+
+*Legionella pneumophila*
+
+- [legsta](https://github.com/tseemann/legsta) v0.5.1 (SBT)
+
+*Mycobacterium tuberculosis*
+
+- [TBProfiler](https://pubmed.ncbi.nlm.nih.gov/31234910/) v6.2.1
+  (spoligotyping, lineage, antimicrobial resistance)
+
+*Neisseria gonorrhoeae*
+
+- [pyngoST](https://pubmed.ncbi.nlm.nih.gov/38288762/) v1.1.2 (MLST,
+  NG-MAST, NG-STAR, *penA*)
+
+*Neisseria meingitidis*
+
+- [meningotype](https://github.com/MDU-PHL/meningotype) v0.8.5 (MLST,
+  serotype, Finetype, Bexsero antigen typing, MenDeVAR Index)
+
+*Streptococcus agalactiae* (GBS)
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- [GBS-SBG](https://pubmed.ncbi.nlm.nih.gov/34895403/) (git commit
+  9e53847) (capsule)
+
+*Streptococcus pneumoniae*
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- [PneumoKITy](https://pmc.ncbi.nlm.nih.gov/articles/PMC9837567/) v1.0
+  (capsule)
+
+*Streptococcus pyogenes* (GAS)
+
+- [mlst](https://github.com/tseemann/mlst) schema
+  [2024-06-10](https://www.pubmlst.org)
+- [emm-typer](https://github.com/MDU-PHL/emmtyper) v0.2.0
+- [assembly_typer](https://github.com/boasvdp/assembly_snptyper) v0.1.0
+  ([M1UK](https://pubmed.ncbi.nlm.nih.gov/31519541/),
+  [M1DK](https://pubmed.ncbi.nlm.nih.gov/38961826/))

--- a/content/docs/whatsgnu_panallelome.md
+++ b/content/docs/whatsgnu_panallelome.md
@@ -1,0 +1,196 @@
+---
+title: WhatsGNU protein allele frequencies
+weight: 115
+toc: true
+---
+
+WhatsGNU computes the frequency of each protein allele across all
+bacterial genomes. For every protein in a query genome, the WhatsGNU
+score (GNU score) reports how many of the 2,438,285 AllTheBacteria
+genomes carry an identical copy of that protein sequence.
+
+This is useful for identifying conserved versus rare alleles,
+understanding species-level protein diversity, and contextualising novel
+genomes against all publicly available bacterial data.
+
+## What is available
+
+The pre-built WhatsGNU database covers 2,438,285 genomes from
+AllTheBacteria (release 0.2 plus incremental release 2024-08). It is
+built from the Bakta protein annotations (`.faa` files).
+
+The following files are available on the [WhatsGNU OSF
+component](https://osf.io/6jr4u/):
+
+| Folder | Description |
+|---|---|
+| `WGNU_ATB_DB/` | Pre-built LMDB database (8 count shards, 8 posting shards, genome-to-species index, function lookup table, Sample-to-ID mapping, build metadata). Required for querying. |
+| `Sample_tables/` | List of included genomes (`final_2438285_genomes.txt`), species statistics, and per-genome/per-species allele record counts. |
+| `ATB_hash_seq/` | Hash-to-amino-acid-sequence lookup table, split into 20 xz-compressed parts (`hash_to_sequence_part_00.xz` - `part_19.xz`). |
+| `ATB_summary_figures_tables/` | Publication figures, per-species GNU histograms, allele frequency tables, species-sharing networks, coverage estimates, cross-species allele analyses, and the pre-computed counts cache. |
+| `panallelome_summary.txt` | Summary results for 2.4M genomes. |
+| `panallelome_summary.html` | Summary results with selected summary figures for 2.4M genomes. |
+
+## Installation
+
+**Option A - Conda (recommended, once available on bioconda)**
+
+```bash
+conda install -c bioconda whatsgnu-atb
+```
+
+**Option B - pip**
+
+```bash
+pip install whatsgnu-atb
+```
+
+**Option C - From source**
+
+```bash
+git clone https://github.com/microbialARC/WhatsGNU-ATB.git
+bash WhatsGNU-ATB/setup_whatsgnu_atb.sh
+conda activate whatsgnu-atb
+```
+
+## Downloading the database
+
+Use the included downloader to fetch data from OSF. No OSF account or
+token is required - the project is public.
+
+**Download the database (required for querying):**
+
+```bash
+python WhatsGNU-ATB/scripts/download_osf.py \
+    --folder WGNU_ATB_DB \
+    --out-dir ./WGNU_ATB_DB
+```
+
+**Download everything:**
+
+```bash
+python WhatsGNU-ATB/scripts/download_osf.py \
+    --all \
+    --out-dir ./WGNU_ATB_DB
+```
+
+**List available folders:**
+
+```bash
+python WhatsGNU-ATB/scripts/download_osf.py --list
+```
+
+The downloader skips files that have already been downloaded with the
+correct size, so it is safe to rerun if a download is interrupted.
+
+## Querying a genome
+
+Your input must be a protein FASTA (`.faa`) file. If your genome has not
+yet been annotated with Bakta, see the [Annotation](/docs/annotation/)
+documentation.
+
+### Basic query (GNU scores only)
+
+```bash
+python WhatsGNU-ATB/scripts/Query_WhatsGNU_ATB.py \
+    --db_dir WGNU_ATB_DB \
+    --shards 8 \
+    --faa your_genome.bakta.faa \
+    --out_dir results/
+```
+
+This produces `your_genome.bakta.faa.whatsgnu.tsv` with one row per
+protein, including its BLAKE2b hash and GNU score.
+
+### Full query (with species breakdown and genome similarity)
+
+```bash
+python WhatsGNU-ATB/scripts/Query_WhatsGNU_ATB.py \
+    --db_dir WGNU_ATB_DB \
+    --shards 8 \
+    --faa your_genome.bakta.faa \
+    --include_sequence \
+    --with_postings \
+    --samples_tsv WGNU_ATB_DB/samples_with_ids.tsv \
+    --species_names_tsv WGNU_ATB_DB/samples_with_ids.tsv \
+    --top_k_species 5 \
+    --top_k_genomes 10 \
+    --out_dir results/
+```
+
+### Querying multiple genomes
+
+Pass a directory of `.faa` files instead of a single file:
+
+```bash
+python WhatsGNU-ATB/scripts/Query_WhatsGNU_ATB.py \
+    --db_dir WGNU_ATB_DB \
+    --shards 8 \
+    --faa directory_of_faa_files/ \
+    --include_sequence \
+    --with_postings \
+    --out_dir results_batch/
+```
+
+## Output files
+
+| File | Description |
+|---|---|
+| `<sample>.whatsgnu.tsv` | Per-protein results: protein ID, BLAKE2b allele hash, GNU score (allele frequency across 2.4M genomes), and optionally the amino acid sequence and top species contributing to each allele. |
+| `<sample>.similarity.tsv` | Genome similarity report: ranks the genomes in AllTheBacteria that share the most protein alleles with the query, with species information and percentage of query proteome shared (requires `--with_postings`). |
+
+## Interpreting GNU scores
+
+The GNU score for a protein is the number of genomes (out of 2,438,285)
+that contain an identical copy of that exact amino acid sequence:
+
+- **High GNU score** (e.g. >100,000): a highly conserved allele found
+  across many genomes and likely multiple species.
+- **Moderate GNU score** (e.g. 1000-100,000): a common allele, often
+  species- or genus-specific.
+- **Low GNU score** (e.g. 1-100): a rare allele, possibly
+  strain-specific or recently evolved.
+- **GNU score = 0**: unique to your query genome - not found in any
+  other AllTheBacteria genome.
+
+## Hash-to-sequence lookup
+
+The `ATB_hash_seq/` folder contains the mapping from each allele hash to
+its full amino acid sequence, split into 20 compressed parts. To
+reassemble:
+
+```bash
+python WhatsGNU-ATB/scripts/download_osf.py \
+    --folder ATB_hash_seq \
+    --out-dir ./whatsgnu_db
+
+cd whatsgnu_db/ATB_hash_seq/
+cat hash_to_sequence_part_*.xz | xz -d > hash_to_sequence.tsv
+```
+
+## Building a custom database
+
+To build a new database from your own set of genomes, use
+`WhatsGNU_ATB_DB.py`. See the [GitHub
+repository](https://github.com/microbialARC/WhatsGNU-ATB) for full build
+documentation, including resumable builds, local scratch options, and
+all available parameters.
+
+## Reproducibility
+
+Full methods, commands, software versions, and all scripts used to build
+the AllTheBacteria WhatsGNU database are available in the [GitHub
+reproducibility
+directory](https://github.com/AllTheBacteria/AllTheBacteria/tree/main/reproducibility/All-samples/whatsgnu-panallelome).
+
+## Citation
+
+If you use WhatsGNU-ATB in your research, please cite:
+
+> Moustafa AM and Planet PJ. WhatsGNU: a tool for identifying proteomic
+> novelty. *Genome Biology*, 2020.
+> [doi:10.1186/s13059-020-01965-w](https://doi.org/10.1186/s13059-020-01965-w)
+>
+> AllTheBacteria - all bacterial genomes assembled, available and
+> searchable. *bioRxiv*, 2024.
+> [doi:10.1101/2024.03.08.584059](https://doi.org/10.1101/2024.03.08.584059)

--- a/content/resources/_index.md
+++ b/content/resources/_index.md
@@ -15,7 +15,7 @@ layout: hextra-home
   {{< hextra/feature-card
     title="Documentation"
     icon="document-search"
-    link="https://allthebacteria.readthedocs.io/en/latest/"
+    link="/docs/"
     subtitle="Full documentation on all aspects of the data"
     class="hx:aspect-auto hx:md:aspect-[1.1/1] hx:max-lg:min-h-[340px]"
     style="background: radial-gradient(ellipse at 50% 80%,rgba(142,53,74,0.15),hsla(0,0%,100%,0));"
@@ -38,7 +38,7 @@ layout: hextra-home
   {{< hextra/feature-card
     title="Files on the cloud"
     icon="cloud-download"
-    link="https://allthebacteria.readthedocs.io/en/latest/assemblies.html#downloading-assemblies-from-aws"
+    link="/docs/assemblies/#downloading-assemblies-from-aws"
     subtitle="Cloud access to assemblies and search indices, enabled by AWS Open Data programme"
     style="background: radial-gradient(ellipse at 50% 80%,rgba(78, 59, 221, 0.15),hsla(0,0%,100%,0));"
   >}}
@@ -46,7 +46,7 @@ layout: hextra-home
     title="How to contribute data"
     icon="sparkles"
     subtitle="We welcome you to join the ATB contributors!"
-    link="https://allthebacteria.readthedocs.io/en/latest/contributing.html"
+    link="/docs/contributing/"
     style="background: radial-gradient(ellipse at 50% 80%,rgba(59, 191, 221, 0.15),hsla(0,0%,100%,0));"
   >}}
 


### PR DESCRIPTION
## Summary

  This PR moves the AllTheBacteria documentation from Read the Docs into this Hugo website and updates the site to use the new in-site docs.

  ## Main changes
  - removed the highlighted features on the docs landing page, and instead simplified to a table of contents
  - migrated the Read the Docs .rst content into Markdown pages under content/docs/
  - replaced Read the Docs links in the site with links to /docs/...
  - added an OSF links page linking docs sections to the relevant OSF project/component pages
  - updated the contributing docs to reflect the new workflow:
      - documentation now lives in ATB_website
      - contributors should send a separate PR for website docs
      - docs page ordering is controlled by Hugo weight
  - renumbered docs page weights to 10, 20, 30, ... to make future insertions easier

  ## Follow-up

  A remaining content issue is the Species specific typing page, where the docs content and currently discoverable OSF components do not fully line up yet.
  
 There's a PR on the main AllTheBacteria that partially addresses it (https://github.com/AllTheBacteria/AllTheBacteria/pull/88).
 There's an issue here describing the details: https://github.com/AllTheBacteria/AllTheBacteria/issues/105
 
 When the PR is merged, I can update the website