### PR TITLE
Add sketchlib 202505

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -8,7 +8,7 @@ toc: false
 AllTheBacteria is a large-scale, collaborative, open-access project that assembles, annotates, and catalogs millions of bacterial and archaeal genomes from public sequencing data.
 
 {{< callout type="info" >}}
-  2,440,377 assemblies in total (as of August 2024)
+  2,763,297 assemblies in total (as of May 2025)
 {{< /callout >}}
 
 {{< figure

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -19,6 +19,7 @@ toc: true
 - [Species specific typing](/docs/typing/)
 - [Archaea](/docs/archaea/)
 - [Sequence alignment with LexicMap](/docs/lexicmap/)
+- [Sequence distances with sketchlib](/docs/sketchlib/)
 - [Contributing to AllTheBacteria](/docs/contributing/)
 - [Batch downloading from OSF](/docs/osf_downloads/)
 - [FAQ](/docs/faq/)

--- a/content/docs/osf_links.md
+++ b/content/docs/osf_links.md
@@ -22,4 +22,5 @@ matching OSF destination.
 | [Biosynthetic gene clusters](/docs/bgcs/) | [GECCO component](https://osf.io/cufb2/) |
 | [Hypothetical protein structures](/docs/hypothetical_protein_structures/) | [Structure databases component](https://osf.io/x693m/) |
 | [Species specific typing](/docs/typing/) | [Acinetobacter baumannii serotyping](https://osf.io/vjma7/), [Bacillus cereus group](https://osf.io/8ua49/), [Clostridium perfringens toxinotyping](https://osf.io/djhga/), [Listeria monocytogenes LisSero typing](https://osf.io/9cbqg/), [Shigella serotyping and species ID](https://osf.io/6a8mv/), [Vibrio parahaemolyticus serotyping](https://osf.io/xc26j/) |
+| [sketchlib](/docs/sketchlib/) | [sketchlib component](https://osf.io/rceq5) |
 | [Archaea](/docs/archaea/) | [Archaea component](https://osf.io/nehtp/) |

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -35,7 +35,7 @@ Post-assembly analysis status
 | [Biosynthetic gene clusters](/docs/bgcs/)      | ✓    | ✓       | ✗       |
 | [Defense systems](/docs/defense/)              | ✓    | ✓       | ✗       |
 
-\[1\]: The indexes are for r0.2 plus 2024-08 (and 20205-05)  combined, not two separate
+\[1\]: The indexes are for r0.2 plus 2024-08 (and 2025-05)  combined, not two separate
 indexes.
 
 ### Archaea

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -6,7 +6,7 @@ toc: true
 
 ## Current status
 
-Date updated: 2026-02-26.
+Date updated: 2026-04-09.
 
 ### Bacteria
 
@@ -28,14 +28,14 @@ Post-assembly analysis status
 | assembly-stats                            | ✓    | ✓       | ✓       |
 | checkm2                                   | ✓    | ✓       | ✓       |
 | [Lexicmap index](/docs/lexicmap/) <sup>1</sup> | ✓    | ✓       | ✗       |
-| sketchlib index <sup>1</sup>              | ✓    | ✓       | ✗       |
+| [sketchlib index ](/docs/sketchlib/) <sup>1</sup>              | ✓    | ✓       | ✓       |
 | [Annotation](/docs/annotation/)                | ✓    | ✓       | ✗       |
 | [Antimicrobial resistance](/docs/amr/)         | ✓    | ✓       | ✗       |
 | [Species-specific typing](/docs/typing/)       | ✓    | ✓       | ✗       |
 | [Biosynthetic gene clusters](/docs/bgcs/)      | ✓    | ✓       | ✗       |
 | [Defense systems](/docs/defense/)              | ✓    | ✓       | ✗       |
 
-\[1\]: The indexes are for r0.2 plus 2024-08 combined, not two separate
+\[1\]: The indexes are for r0.2 plus 2024-08 (and 20205-05)  combined, not two separate
 indexes.
 
 ### Archaea

--- a/content/docs/sketchlib.md
+++ b/content/docs/sketchlib.md
@@ -1,0 +1,38 @@
+---
+title: Sequence distances with sketchlib
+weight: 145
+toc: true
+---
+
+Sketchlib is a tool for rapid sketching and distance estimation, which is
+available from https://github.com/bacpop/sketchlib.rust.
+
+Sketchlib indexes are available from OSF here: https://osf.io/rceq5/overview.
+
+The latest index, which is all assemblies up to and including
+incremental release 202505 (ie it is release 0.2 plus incremental releases
+202408 and 202505), is in the files
+`Aggregated/atb_sketchlib.aggregated.202505.skd` and
+`Aggregated/atb_sketchlib.aggregated.202505.skm`.
+Older index files are also available.
+
+The distributed indexes have sketch size `1024` with `k=17`.
+
+To calculate distances of a subset of the data, use a command such as:
+```
+sketchlib dist -v -k 17 --subset Haemophilus_influenzae.txt --ani atb_sketchlib.aggregated.202505 --threads 4 > dists.txt
+```
+Where the `--subset` file contains the list of samples you want to include.
+Removing `--ani` will calculate Jaccard distances.
+
+To query new samples against the index, first sketch it:
+```
+sketchlib sketch -v -o query -k 17 -f queries.tsv -s 1024
+```
+(where `queries.tsv` contains query samples with name and file location, tab separated)
+
+Then query it
+```
+sketchlib dist -v -k 17 atb_sketchlib.aggregated.202505 query
+```
+


### PR DESCRIPTION
Adds:
* sketchlib docs
* link to osf in osf links table

Also updated the relevant numbers on the overview page, and headline number of main index page