### PR TITLE
Add reverse proxy for /browse to separately hosted data browser

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,8 @@ HUGO_VERSION = "0.145.0"
 from = "/npmjs/*"
 to = "/npmjs/"
 status = 200
+
+[[redirects]]
+from = "/browse/*"
+to = "https://atb-explorer-web.onrender.com/browse/:splat"
+status = 200


### PR DESCRIPTION
**Why**
I've been working on a data browser for ATB data, and after discussing with @johnlees and @iqbal-lab we thought it could be included in the main allthebacteria.org website. To minimize upfront integration work, we decided to initially embed the data browser as a separately hosted app using Netlify's built-in reverse proxy.

**What**
This PR add's a reverse proxy rule to `netlify.toml` that points `/browse` to a Render-hosted React app (atb-explorer-web.onrender.com). The data browser includes a near-identical replica of the navbar, which should give the end users a unified experience.

**Preview**
A live preview of the end result is visible at https://atb-website-ts-fork.netlify.app/browse. That's a fork of the full ATB_website, so it also verifies the reverse proxy approach. The live preview site (and my ATB_website repo fork) are intended to be removed after merging.

**Notes**
- This PR makes `/browse` technically available on the AllTheBacteria website, but it does NOT yet add it to the navbar. This is good because I still want to do some finishing touches to the data browser before its release
- The near-identical navbar has two known deviations from the original: the search bar is disabled, and the mobile navbar 
doesn't show direct links to the docs subpages (only the main docs page). The navbar also needs to be manually updated if `ATB_website` navbar is changes
- The data browser currently only supports dark mode for its navbar, not the page contents

**Screenshot**
<img width="3000" height="1574" alt="Screenshot 2026-06-15 at 14 20 38" src="https://github.com/user-attachments/assets/68958b4d-9596-4c87-8769-1ebb1cccb12e" />