### PR TITLE
Refactor docs around atb CLI

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -22,6 +22,10 @@ Designed to support the global microbiology community, it provides standardized,
 
 We provide multiple types of search tools (e.g. [sketchlib](https://github.com/bacpop/sketchlib.rust) and [sourmash](https://sourmash.readthedocs.io/en/latest/) for finding similar genomes to a query, and [Lexicmap](https://bioinf.shenwei.me/LexicMap/) for BLAST-style alignment to the full dataset).
 
+For command line querying, assembly downloads, AMR/MLST searches, OSF
+file browsing, and sketchlib nearest-neighbour searches, start with the
+[ATB command line tool](/docs/cli/).
+
 Please feel free to use the data, and to join us if you see analyses on your favourite species that would be valuable to all.
 
 {{< figure
@@ -30,5 +34,4 @@ Please feel free to use the data, and to join us if you see analyses on your fav
   height=300
   class="ma0 w-75"
 >}}
-
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -5,6 +5,7 @@ toc: true
 ---
 
 - [Overview](/docs/overview/)
+- [Command line tool](/docs/cli/)
 - [Metadata and QC](/docs/sample_metadata/)
 - [OSF links](/docs/osf_links/)
 - [SQLite metadata](/docs/metadata_sqlite/)
@@ -21,7 +22,7 @@ toc: true
 - [Sequence alignment with LexicMap](/docs/lexicmap/)
 - [Sequence distances with sketchlib](/docs/sketchlib/)
 - [Contributing to AllTheBacteria](/docs/contributing/)
-- [Batch downloading from OSF](/docs/osf_downloads/)
+- [Browsing and downloading from OSF](/docs/osf_downloads/)
 - [FAQ](/docs/faq/)
 - [Release history](/docs/release_history/)
 - [Migration from EBI FTP to OSF](/docs/ebi2osf/)

--- a/content/docs/amr.md
+++ b/content/docs/amr.md
@@ -19,6 +19,28 @@ version used.
 
 The current version of the AMRFinderPlus results were run using a Nextflow pipeline [found here](https://github.com/jhawkey/atb-amrfp-nf/tree/main) using **AMRFinderPlus version v4.2.5 with database 2025-12.03.1**.
 
+For routine queries, use `atb amr`. This reads the `amrfinderplus.parquet`
+table from the 2025-05 aggregated metadata:
+
+```bash
+atb fetch
+
+# AMR hits for high-quality E. coli genomes
+atb amr --species "Escherichia coli" --hq-only --limit 100
+
+# Filter by drug class or gene
+atb amr --species "Escherichia coli" --class "BETA-LACTAM"
+atb amr --gene "blaCTX-M-15" --limit 100
+
+# Include optional ENA metadata columns
+atb fetch --tables ena_20250506.parquet
+atb amr --species "Escherichia coli" --class "BETA-LACTAM" --with-ena
+
+# Download assemblies matching an AMR query
+atb amr --species "Klebsiella pneumoniae" --gene "blaCTX-M-15" \
+  --download --dry-run
+```
+
 Genomes were matched to the organism available in AMRFinderPlus where possible; a table linking each ATB species to its corresponding AMRFinderPlus species [can be found here](https://github.com/jhawkey/atb-amrfp-nf/blob/main/unique_ATB_spp.txt).
 
 Each table of results has a matched status file. The status file

--- a/content/docs/annotation.md
+++ b/content/docs/annotation.md
@@ -28,6 +28,17 @@ to meet the 5 GB file limit. By doing so, all annotation data could be
 reduced to a total of ~1.3 TB and ~0.3 TB for `r0.2` and
 `incr_release.202408`, respectively.
 
+Use `atb osf` to find and download Bakta files from the command line:
+
+```bash
+atb osf ls --grep "bakta.*status"
+atb osf ls --grep "bakta.*batch"
+atb osf download --dry-run "Bakta.*status"
+```
+
+For very large downloads, use `--verify` to check MD5 sums after
+download.
+
 For each release, there is a status file in a `File_Lists` folder, e.g.
 `atb.bakta.r0.2.status.tsv.gz` providing
 the following information:

--- a/content/docs/archaea.md
+++ b/content/docs/archaea.md
@@ -16,6 +16,13 @@ are here: <https://osf.io/nehtp/>. The only exception is that, because
 there are relatively few samples, each release of assemblies consists of
 a single tarball of FASTA files (as opposed to 100s of tarballs).
 
+The `atb osf` commands can be used to browse and download the OSF files:
+
+```bash
+atb osf ls Archaea
+atb osf download --project AllTheBacteria/Archaea --all -o ./archaea
+```
+
 For a description of the files and metadata etc, please read the
-[Assemblies](/docs/assemblies/) and [batch downloading](/docs/osf_downloads/)
+[Assemblies](/docs/assemblies/) and [OSF downloads](/docs/osf_downloads/)
 pages.

--- a/content/docs/assemblies.md
+++ b/content/docs/assemblies.md
@@ -6,15 +6,47 @@ toc: true
 
 ## Summary
 
-Assemblies can be downloaded from OSF, AWS, or the ENA.
+Assemblies can be downloaded with the [ATB command line tool](/docs/cli/),
+or directly from OSF, AWS, or the ENA.
 
+- For routine use, use `atb query` and `atb download`.
 - Batched assemblies are on OSF. If you want all assemblies or large
-  numbers then get them from OSF.
+  numbers outside the CLI, get them from OSF.
 - Individual FASTA files for each sample are on AWS. If you want
-  assemblies for specific samples then AWS will be easiest.
+  assemblies for specific samples outside the CLI, AWS will be easiest.
 - Individual FASTA files are also available from the ENA. However,
   around 10,000 assemblies are not available from the ENA, since the
   submission system rejected them due to various errors.
+
+## Recommended: command line downloads
+
+The CLI uses the aggregated data up to and including incremental release
+2025-05. Query the metadata first, then download the matching assemblies:
+
+```bash
+atb fetch
+atb query --species "Klebsiella pneumoniae" --hq-only \
+  --columns sample_accession,sylph_species,N50,aws_url \
+  --limit 10 -o klebsiella.tsv
+atb download --from klebsiella.tsv --output-dir ./klebsiella_genomes
+```
+
+You can also download one assembly directly:
+
+```bash
+atb download --url https://allthebacteria-assemblies.s3.eu-west-2.amazonaws.com/SAMD00000355.fa.gz \
+  --output-dir ./genomes
+```
+
+For bulk OSF assembly batches, including extraction and recompression:
+
+```bash
+atb osf download --project AllTheBacteria/Assembly --all \
+  --extract --compress gz --delete-archive -o ./assemblies
+```
+
+The sections below are manual download methods for power users who need
+direct URLs, exact archive names, ENA accessions, or custom pipelines.
 
 ## Downloading assemblies from AWS
 
@@ -138,6 +170,13 @@ Older files (pre-202505) have these two columns:
 If you want to download the archives in bulk, then use the `tar_xz_url`
 column to get the urls, and `tar_xz` for what you should name the
 downloaded file. OSF does not have the filename in the download URL.
+
+The CLI can do this directly, with optional extraction:
+
+```bash
+atb osf download --project AllTheBacteria/Assembly --all \
+  --extract --compress gz --delete-archive -o ./assemblies
+```
 
 Here's an example of how to get the wget commands to run:
 

--- a/content/docs/bgcs.md
+++ b/content/docs/bgcs.md
@@ -19,6 +19,13 @@ for the v0.2 release and the incremental release (08-2024), as well as a
 pair of files which contains both the v0.2 and the incremental release
 (08-2024).
 
+Use `atb osf` to browse and download the GECCO files:
+
+```bash
+atb osf ls GECCO
+atb osf download --verify "GECCO.*clusters"
+```
+
 Also available is a status file indicating which genomes (`samples`
 column) have been processed. As of now, that includes all genomes
 present in release v0.2 and in the incremental release (08-2024), and

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -1,0 +1,101 @@
+---
+title: Command line tool
+weight: 15
+toc: true
+---
+
+The `atb` command line tool is the recommended way to query
+AllTheBacteria metadata, download assemblies, browse OSF files, search
+AMR/MLST results, and query the sketchlib index. It uses the aggregated
+data up to and including incremental release 2025-05.
+
+The full command reference is maintained with the tool:
+<https://allthebacteria.github.io/atb-cli/>.
+
+## Install
+
+On Linux or macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/allthebacteria/atb-cli/main/install.sh | bash
+```
+
+Pre-built binaries for Linux, macOS, and Windows are available from:
+<https://github.com/allthebacteria/atb-cli/releases/latest>.
+
+## First use
+
+Choose a data directory on a disk with enough space. The default
+metadata fetch includes AMR data and builds local indexes; this can use
+roughly 35 GB. Add another few GB if you fetch the sketchlib index.
+
+```bash
+atb config set general.data_dir /path/to/large/volume/atb-data
+atb fetch
+atb query --species "Escherichia coli" --hq-only --limit 10
+```
+
+If you do not need AMR queries, fetch only the core non-AMR tables:
+
+```bash
+atb fetch --tables assembly.parquet,assembly_stats.parquet,checkm2.parquet,sylph.parquet,run.parquet,mlst.parquet
+```
+
+## Common tasks
+
+Query genomes and select useful columns:
+
+```bash
+atb query --species "Klebsiella pneumoniae" --hq-only \
+  --columns sample_accession,sylph_species,N50,Completeness_General,aws_url \
+  --limit 20
+```
+
+Download assemblies from a query:
+
+```bash
+atb query --species "Escherichia coli" --hq-only \
+  --columns sample_accession,aws_url --limit 10 -o ecoli.tsv
+atb download --from ecoli.tsv --output-dir ./ecoli_genomes
+```
+
+Browse and download files from OSF:
+
+```bash
+atb osf ls
+atb osf ls AMR
+atb osf download --verify "AMRFinderPlus.*latest"
+```
+
+Query AMRFinderPlus results:
+
+```bash
+atb amr --species "Escherichia coli" --class "BETA-LACTAM" --hq-only
+atb amr --gene "blaCTX-M-15" --limit 100
+```
+
+Query MLST calls:
+
+```bash
+atb mlst --species "Escherichia coli" --st 131 --hq-only
+atb mlst --scheme salmonella --limit 50
+```
+
+Find closest genomes with sketchlib:
+
+```bash
+atb sketch install
+atb sketch fetch
+atb sketch query my_genome.fasta --knn 50
+```
+
+The CLI installs sketchlib `v0.2.4` when you run `atb sketch install`.
+The ATB sketch database used by the website documentation is the
+aggregated 2025-05 sketchlib index.
+
+## When to use manual methods
+
+The manual OSF, AWS, ENA, and SQLite instructions in these docs are kept
+for power users who need exact archive paths, direct database access,
+custom pipelines, or reproducible low-level commands. For routine
+querying and downloads, start with `atb`.

--- a/content/docs/defense.md
+++ b/content/docs/defense.md
@@ -10,6 +10,13 @@ species with \>400 samples from release 0.2 plus incremental release
 component](https://osf.io/hpgac/overview). This includes 27 species and
 1,166,956 samples.
 
+Use `atb osf` to find and download the result files:
+
+```bash
+atb osf ls DefenseFinder
+atb osf download --verify "DefenseFinder.*results"
+```
+
 Note that this analysis is all with DefenseFinder
 [v1.3.0](https://github.com/mdmparis/defense-finder/releases/tag/v1.3.0)
 using the profiles from defense-finder-models v1.3.0 and CasFinder

--- a/content/docs/hypothetical_protein_structures.md
+++ b/content/docs/hypothetical_protein_structures.md
@@ -71,6 +71,16 @@ specific container tag `rocm6_cpuTF` available at
 
 ## Files
 
+Use `atb osf` to browse and download the structure files and metadata:
+
+```bash
+atb osf ls "Protein Structures"
+atb osf download --dry-run "Protein Structures.*ATB_AFDB_map"
+```
+
+The commands below describe how the split files are assembled after
+download.
+
 ### Foldseek Database
 
 We provide a Foldseek database (created using `foldseek createdb`) via

--- a/content/docs/lexicmap.md
+++ b/content/docs/lexicmap.md
@@ -127,6 +127,16 @@ Tools:
 - [LexicMap](https://bioinf.shenwei.me/LexicMap/installation/)
 - <https://github.com/shenwei356/rush>, for running jobs in parallel
 
+The recommended way to download and extract ATB assembly batches for a
+local LexicMap build is:
+
+    atb osf download --project AllTheBacteria/Assembly --all \
+        --extract --compress gz --delete-archive -o atb
+
+This replaces the manual file-list, URL extraction, `wget`, and `tar`
+steps for most users. The original manual workflow is kept below for
+power users who want exact control over each step.
+
 Steps:
 
 1.  Downloading the list file of all [assemblies](https://osf.io/zxfmy/)
@@ -135,7 +145,7 @@ Steps:
         mkdir -p atb;
         cd atb;
 
-        # Attention, the URL might changes,
+        # Attention, the URL might change,
         # please check in the browser: https://osf.io/zxfmy/files/osfstorage
         # This url is for v0.2 + incr_202408 + incr_202505.
         wget https://osf.io/download/3xs6h/ -O file_list.all.latest.tsv.gz
@@ -205,7 +215,7 @@ Steps:
 
         lexicmap index -S -X files.txt -O atb.lmi -b 25000 --log atb.lmi.log
 
-        # It's for the v0.2 + 2024008
+        # It's for the v0.2 + 202408
         #
         # dirsize atb.lmi
         atb.lmi: 5.24 TiB (5,758,875,365,595)

--- a/content/docs/metadata_sqlite.md
+++ b/content/docs/metadata_sqlite.md
@@ -12,6 +12,21 @@ incremental release 2024-08.
 This is very detailed; if you just want simple flat files, then please
 see the [Metadata and QC](/docs/sample_metadata/) page.
 
+For routine filtering and sample lookups, use the
+[ATB command line tool](/docs/cli/) instead of downloading and
+decompressing the full SQLite database:
+
+```bash
+atb fetch
+atb query --has-assembly --limit 20
+atb query --has-assembly --min-n50 1000000 \
+  --columns sample_accession,dataset,total_length,N50
+atb info SAMN02391170
+```
+
+The SQLite database is still useful for power users who need direct SQL,
+custom joins, or a complete local copy of the database schema.
+
 The 202505 SQLite database is in the file
 `atb.metadata.202505.sqlite.xz`, available from OSF at:
 <https://osf.io/h7wzy/files/my56u>.
@@ -238,7 +253,7 @@ The columns of the table are:
   assembly.
 - `asm_pipe_filter`: a list of filters that this sample fails, or `PASS`
   if it passed all filters (similar to how the VCF filter column works).
-  This is onlt for the assembly pipeline. See also the columns
+  This is only for the assembly pipeline. See also the columns
   `sylph_filter` and `hq_filter`. This column uses the latest filters,
   not those used initially to find samples to process. This means a
   sample could be in the 661k, release 0.2 or incremental releases but
@@ -393,13 +408,24 @@ which case all fields except for `sample_accession` and
 
 ## Example SQLite queries
 
+The CLI equivalents are shown first where they exist. The SQL is kept
+for power users who want to query the SQLite database directly.
+
 Get all samples that have an assembly on OSF/AWS, ie this is release 0.2
 (which includes 661k) and incremental releases 2024-08, 2025-05:
+
+    atb query --has-assembly
 
     SELECT * FROM assembly WHERE asm_fasta_on_osf=1;
 
 Get the sample and ENA assembly accessions of all samples in incremental
 release 2024-08 that have an ENA accession:
+
+The CLI can list the relevant columns; filter out `NA` accessions
+downstream if needed:
+
+    atb query --dataset Incr_release.202408 --has-assembly \
+      --columns sample_accession,assembly_accession
 
     SELECT sample_accession,assembly_accession
     FROM assembly
@@ -407,11 +433,20 @@ release 2024-08 that have an ENA accession:
 
 Get all samples with an assembly on OSF/AWS with N50 at least 1000000:
 
+    atb query --has-assembly --min-n50 1000000 \
+      --columns sample_accession,dataset,total_length,N50
+
     SELECT assembly.sample_accession, assembly.dataset, assembly_stats.total_length, assembly_stats.N50
     FROM assembly JOIN assembly_stats ON assembly.sample_accession = assembly_stats.sample_accession
     WHERE assembly_stats.N50 > 1000000 AND assembly.asm_fasta_on_osf=1;
 
 Get the assembly info and ENA 20240801 metadata for sample SAMN02391170:
+
+For current sample details, use:
+
+    atb info SAMN02391170
+
+For the exact 2024-08 ENA snapshot join, use SQL:
 
     SELECT * FROM assembly
     JOIN ena_20240801 ON assembly.sample_accession = ena_20240801.sample_accession

--- a/content/docs/osf_downloads.md
+++ b/content/docs/osf_downloads.md
@@ -1,28 +1,52 @@
 ---
-title: Batch downloading from OSF
+title: Browsing and downloading from OSF
 weight: 160
 toc: true
 ---
 
 The data are all hosted on OSF: <https://osf.io/xv7q9/>
 
-If you only want a few files, then browsing the website an manually
-downloading works fine. This page describes how to download files in
-bulk. It is not immediately obvious how to do so, because you need to
-get the URLs of the files you want to download.
+If you only want a few files, then browsing the website and manually
+downloading works fine. For command line access, the recommended route
+is `atb osf`, which uses the project file index and can verify MD5 sums.
+
+```bash
+atb osf ls
+atb osf ls AMR
+atb osf ls --grep "bakta.*batch"
+atb osf download --dry-run "AMRFinderPlus.*latest"
+atb osf download --verify "DefenseFinder.*results"
+```
+
+Download every file in one project/component:
+
+```bash
+atb osf download --project AllTheBacteria/MLST --all -o ./mlst_data
+```
+
+Download and extract assembly tarballs:
+
+```bash
+atb osf download --project AllTheBacteria/Assembly --all \
+  --extract --compress gz --delete-archive -o ./assemblies
+```
+
+The rest of this page documents the underlying file index and manual
+methods for power users who want to script their own downloads.
 
 ## All latest files
 
 We provide a tab-delimited file of all the files that are on OSF for the
 whole AllTheBacteria project: [all_atb_files.tsv](https://osf.io/r6gcp).
 This is subject to change, and is updated when files change on OSF.
+The `atb osf` commands use this file index internally.
 
 The columns are:
 
 - `project`: the name of the project/component, plus its parents, with
   the names separated by `/`. For example the Metadata component sits
   directly under the main AllTheBacteria project, and is called
-  `AlTheBacteria/Metadata`.
+  `AllTheBacteria/Metadata`.
 - `project_id`: the project identifier. This is useful if you want to
   make your own file list (see below)
 - `filename`: the name of the file
@@ -47,8 +71,8 @@ and then check the MD5 sum is correct.
 
 ## Making file lists
 
-Ignore this section if you just want to use the file list provided by
-us. Otherwise, keep reading.
+Ignore this section if you just want to use `atb osf` or the file list
+provided by us. Otherwise, keep reading.
 
 A file list can be made with this script:
 <https://github.com/martinghunt/bioinf-scripts/blob/master/python/osf_get_files_for_project.py>

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -44,22 +44,27 @@ The only release is 2024-07, and has 815 assemblies.
 
 ## Where are the docs/data/methods?
 
-There are three places to go, depending on what you want:
+There are five places to go, depending on what you want:
 
-1.  Documentation: how to download and use the data/analysis files is
-    described in this documentation you are currently reading
-2.  Files: the data are all hosted on OSF: <https://osf.io/xv7q9/>,
-    which includes assembly and analysis files. For bulk downloads,
-    please read [Bulk Downloads](/docs/osf_downloads/).
-3.  [Assemblies](/docs/assemblies/) are available from OSF, AWS, and the ENA.
-4.  Methods/code: in-depth methods details and files for reproducibility
+1.  Command line access: for routine querying, assembly downloads, AMR
+    and MLST searches, sketchlib queries, and OSF browsing, use the
+    [ATB command line tool](/docs/cli/).
+2.  Documentation: how to understand the data and analysis files is
+    described in this documentation you are currently reading.
+3.  Files: the data are all hosted on OSF: <https://osf.io/xv7q9/>,
+    which includes assembly and analysis files. For direct bulk
+    downloads, please read [Browsing and downloading from OSF](/docs/osf_downloads/).
+4.  [Assemblies](/docs/assemblies/) are available from OSF, AWS, and the ENA.
+5.  Methods/code: in-depth methods details and files for reproducibility
     are stored in this github repository:
     <https://github.com/AllTheBacteria/AllTheBacteria>. If you are just
     using the data, you shouldn't need to look there.
 
 If you only want to use the data without caring about the methods then
-we suggest you read this documentation, which has the relevant links to
-OSF, as opposed to going directly to OSF.
+we suggest you start with the [command line tool](/docs/cli/) and then
+use this documentation for dataset details. The manual OSF/AWS/SQLite
+sections are kept for users who need direct file access or low-level
+database queries.
 
 ## A brief history of AllTheBacteria
 

--- a/content/docs/sample_metadata.md
+++ b/content/docs/sample_metadata.md
@@ -23,13 +23,17 @@ tools) pipeline. They include:
 
 ## Metadata availability
 
-The metadata are available in two forms:
+The metadata are available in three forms:
 
-1.  Flat files. These are described below. This is how all of the data
+1.  Through the [ATB command line tool](/docs/cli/). This is the
+    recommended route for routine filtering, sample lookups, and
+    assembly downloads. It uses Parquet tables and a local query index
+    built by `atb fetch`.
+2.  Flat files. These are described below. This is how all of the data
     was released when we first uploaded everything to OSF in 2024.
-2.  In an [SQLite database](/docs/metadata_sqlite/), available for releases
+3.  In an [SQLite database](/docs/metadata_sqlite/), available for releases
     2024-08 and 2025-05. It gathers together all of the ENA metadata,
-    assembly metadata, plus slpyh, checkm2 and assembly stats output.
+    assembly metadata, plus sylph, checkm2 and assembly stats output.
     The 2024-08 database contains more stringent checks on the metadata,
     and so more samples are flagged as possibly unreliable than in the
     flat files. From 2025-05 onwards, the database has the same
@@ -38,6 +42,15 @@ The metadata are available in two forms:
 This page describes the flat files. It is simpler than the database. The
 details of the metadata and the SQLite database are complicated, and are
 described in a separate page: [SQLite metadata](/docs/metadata_sqlite/)
+
+For common questions, the CLI usually avoids downloading or decompressing
+the full SQLite database:
+
+```bash
+atb fetch
+atb query --species "Salmonella enterica" --hq-only --limit 20
+atb info SAMD00000355
+```
 
 ## Metadata files
 

--- a/content/docs/sketchlib.md
+++ b/content/docs/sketchlib.md
@@ -9,6 +9,21 @@ available from https://github.com/bacpop/sketchlib.rust.
 
 Sketchlib indexes are available from OSF here: https://osf.io/rceq5/overview.
 
+For routine closest-genome searches, use the ATB command line tool. It
+installs sketchlib `v0.2.4` when you run `atb sketch install`.
+
+```bash
+atb sketch install
+atb sketch fetch
+atb sketch query my_genome.fasta --knn 50
+```
+
+The CLI can also download the matching assemblies:
+
+```bash
+atb sketch query my_genome.fasta --knn 50 --download ./closest_genomes
+```
+
 The latest index, which is all assemblies up to and including
 incremental release 202505 (ie it is release 0.2 plus incremental releases
 202408 and 202505), is in the files
@@ -17,6 +32,11 @@ incremental release 202505 (ie it is release 0.2 plus incremental releases
 Older index files are also available.
 
 The distributed indexes have sketch size `1024` with `k=17`.
+
+## Manual sketchlib use
+
+The following commands are for power users who want to call sketchlib
+directly, for example to calculate distances within a subset.
 
 To calculate distances of a subset of the data, use a command such as:
 ```
@@ -35,4 +55,3 @@ Then query it
 ```
 sketchlib dist -v -k 17 atb_sketchlib.aggregated.202505 query
 ```
-

--- a/content/docs/species_id.md
+++ b/content/docs/species_id.md
@@ -14,6 +14,16 @@ consistent set of species calls for everything up to and including
 older (r0.2 and 2024-08) files were not changed and contain the old
 method species calls.
 
+The command line tool queries the 2025-05 aggregated species calls:
+
+```bash
+atb query --species "Escherichia coli" --hq-only --limit 10
+atb query --species-like "Enterococcus%faecium" --hq-only --limit 10
+```
+
+Use `--species-like` when GTDB naming differs from common NCBI names or
+when you want to search across naming variants.
+
 ## ENA species
 
 This is simply the value of the `scientific_name` in the ENA metadata,
@@ -45,7 +55,7 @@ To pass, the Sylph call must have:
 2.  `c * g * (r / (r - k + 1)) >= 0.5 * base_count`, which roughly means
     that at least half of the reads match this genome. Although this may
     sound like a low threshold, sequencing errors have a significant
-    detrimental affect on the calculation.
+    detrimental effect on the calculation.
 
 Further, for a sample (not just a run) to pass, there can be only one
 species call that passes. A sample with more than one run could have two

--- a/content/docs/typing.md
+++ b/content/docs/typing.md
@@ -10,6 +10,29 @@ All [sylph](https://github.com/bluenote-1577/sylph)-identified genomes
 from [AllTheBacteria](/docs/)
 `0.2` and `incremental release 2024-08` were typed using various tools
 
+For standard MLST queries across the aggregated ATB metadata up to and
+including 2025-05, use `atb mlst`:
+
+```bash
+atb fetch
+
+# Get MLST calls for high-quality E. coli genomes
+atb mlst --species "Escherichia coli" --hq-only --limit 20
+
+# Find a sequence type
+atb mlst --species "Escherichia coli" --st 131 --hq-only
+
+# Query by scheme
+atb mlst --scheme salmonella --limit 50
+
+# Download matching assemblies
+atb mlst --species "Escherichia coli" --st 131 --download -d ./st131
+```
+
+The sections below describe species-specific typing analyses that go
+beyond the standard MLST table, such as capsule, toxin, serotype, and
+lineage tools.
+
 *Bacillus cereus* group spp.
 
 - [BTyper3](https://github.com/lmc297/BTyper3) v3.4.0 (Standardized

--- a/content/docs/whatsgnu_panallelome.md
+++ b/content/docs/whatsgnu_panallelome.md
@@ -58,6 +58,16 @@ conda activate whatsgnu-atb
 Use the included downloader to fetch data from OSF. No OSF account or
 token is required - the project is public.
 
+You can also use `atb osf` to discover the hosted WhatsGNU files:
+
+```bash
+atb osf ls WhatsGNU
+atb osf download --dry-run "WhatsGNU.*WGNU_ATB_DB"
+```
+
+Use the WhatsGNU commands below for the database layout and query
+workflow.
+
 **Download the database (required for querying):**
 
 ```bash


### PR DESCRIPTION
Add CLI usage where appropriate, preferring that over unix commands. Still has all the existing unix commands for power users.